### PR TITLE
Fix conflict with Base.collect and Base.norm

### DIFF
--- a/src/SymPy.jl
+++ b/src/SymPy.jl
@@ -23,7 +23,7 @@ import Base: solve, length,  size
 import Base: factor, expand, collect
 import Base: !=, ==
 import Base:  LinAlg.det, LinAlg.inv, LinAlg.conj,
-              cross, eigvals, eigvecs, rref, trace
+              cross, eigvals, eigvecs, rref, trace, norm
 import Base: promote_rule
 import Base: has, match, replace, round
 import Base: ^, .^


### PR DESCRIPTION
SymPy.collect was conflicting with Base.collect:

```
julia> using SymPy
julia> collect(1:3)
ERROR: no method collect(Range1{Int64})
you may have intended to import Base.collect
```

UPDATE: Also fixes conflict with `norm`.
