### PR TITLE
use pycall rather than pyeval and other constructs

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.4
-Compat 0.8.6
+Compat 0.9.0
 PyCall 1.6.0
 RecipesBase 0.0.4

--- a/src/SymPy.jl
+++ b/src/SymPy.jl
@@ -205,12 +205,12 @@ end
 ## Makes it possible to call in a sympy method, witout worrying about Sym objects
 
 global call_sympy_fun(fn::Function, args...; kwargs...) = fn(args...; kwargs...)
-global call_sympy_fun(fn::PyCall.PyObject, args...; kwargs...) = call_sympy_fun(convert(Function, fn), args...; kwargs...)
+global call_sympy_fun(fn::PyCall.PyObject, args...; kwargs...) = PyCall.pycall(fn, PyAny, args...; kwargs...)
 
 ## Main interface to methods in sympy
 ## sympy_meth(:name, ars, kwars...)
 global sympy_meth(meth, args...; kwargs...) = begin
-    ans = call_sympy_fun(convert(Function, sympy[@compat(Symbol(meth))]), args...; kwargs...)
+    ans = call_sympy_fun(sympy[string(meth)], args...; kwargs...)
     ## make nicer...
     try
         if isa(ans, Vector)
@@ -242,16 +242,16 @@ function __init__()
     copy!(sympy, PyCall.pyimport_conda("sympy", "sympy"))
 
     ## mappings from PyObjects to types.
-    basictype = sympy[:basic]["Basic"]
+    basictype = sympy["basic"]["Basic"]
     pytype_mapping(basictype, Sym)
 
-    polytype = sympy[:polys]["polytools"]["Poly"]
+    polytype = sympy["polys"]["polytools"]["Poly"]
     pytype_mapping(polytype, Sym)
 
     try
-        matrixtype = sympy[:matrices]["MatrixBase"]
+        matrixtype = sympy["matrices"]["MatrixBase"]
         pytype_mapping(matrixtype, SymMatrix)
-        pytype_mapping(sympy[:Matrix], SymMatrix)
+        pytype_mapping(sympy["Matrix"], SymMatrix)
     catch e
     end
 

--- a/src/assumptions.jl
+++ b/src/assumptions.jl
@@ -102,7 +102,7 @@ Q_predicates = (:antihermitian,
                 :real_elements,
                 :complex_elements,
                 :integer_elements)
-                
+
 for meth in Q_predicates
         nm = string(meth)
         @eval begin
@@ -110,8 +110,7 @@ for meth in Q_predicates
 `$($nm)`: a SymPy function.
 The SymPy documentation can be found through: http://docs.sympy.org/latest/search.html?q=$($nm)
 """ ->
-            ($meth)(x) = convert(SymPy.Sym, convert(Function, SymPy.sympy[:Q][($nm)])(SymPy.project(x)))
-#            ($meth)(x) = PyCall.pyeval("f(x)", SymPy.Sym, f=SymPy.sympy[:Q][($nm)], x=SymPy.project(x))::SymPy.Sym
+            ($meth)(x) = PyCall.pycall(SymPy.sympy["Q"][$nm], SymPy.Sym, SymPy.project(x))::SymPy.Sym
         end
     end
 end
@@ -120,4 +119,3 @@ end
 
 
 export Q
-

--- a/src/call-0.4.jl
+++ b/src/call-0.4.jl
@@ -8,7 +8,7 @@ function Base.call{T <: SymbolicObject}(ex::T, args...)
         if classname(ex) == "Symbol"
             ex
         else
-            convert(Function, project(ex))(args...)
+            pycall(project(ex), PyAny, args...)
         end
     end
 end
@@ -19,7 +19,7 @@ Base.call(ex::SymbolicObject, x::Pair...) = subs(ex, x...)
 ## for symbolic functinos (dsolve)
 Base.call(u::SymFunction, x::Base.Dict) = throw(ArgumentError("IVPsolutions can only be called with symbolic objects"))
 Base.call(u::SymFunction, x::Base.Pair) = throw(ArgumentError("IVPsolutions can only be called with symbolic objects"))
-function Base.call(u::SymFunction, x::Sym) 
+function Base.call(u::SymFunction, x::Sym)
     if u.n == 0
         u.x(SymPy.project(x))
     else

--- a/src/call.jl
+++ b/src/call.jl
@@ -3,7 +3,7 @@
 ## for symbolic functions (dsolve.jl)
 (u::SymFunction)(x::Base.Dict) = throw(ArgumentError("IVPsolutions can only be called with symbolic objects"))
 (u::SymFunction)(x::Base.Pair) = throw(ArgumentError("IVPsolutions can only be called with symbolic objects"))
-function (u::SymFunction)(x) 
+function (u::SymFunction)(x)
     if u.n == 0
         u.x(SymPy.project(x))
     else
@@ -27,7 +27,7 @@ function (ex::Sym)(args...)
         if classname(ex) == "Symbol"
             ex
         else
-            convert(Function, project(ex))(args...)
+            pycall(project(ex), PyAny, args...)
         end
     end
 end

--- a/src/display.jl
+++ b/src/display.jl
@@ -18,9 +18,7 @@ latex(s::SymbolicObject, args...; kwargs...)  = sympy_meth(:latex, s, args...; k
 
 "create basic printed output"
 function jprint(x::SymbolicObject)
-#    out = py"str($(x.x))"  # 1.8.0 of PyCall is needed in REQUIRE
-    out = PyCall.pyeval("str(x)", x = x.x)
-
+    out = PyCall.pycall(pybuiltin("str"), Compat.UTF8String, x.x)
     if ismatch(r"\*\*", out)
         out = replace(out, "**", "^")
     end
@@ -31,13 +29,13 @@ jprint(x::Array) = map(jprint, x)
 ## show is called in printing tuples, ...
 ## we would like to use pprint here, but it does a poor job on complicated multi-line expressions
 Base.show(io::IO, s::Sym) = print(io, jprint(s))
-Base.show(io::IO, s::Array{Sym}) = print(io, "\n", sympy[:pretty](convert(SymMatrix, s)))
+Base.show(io::IO, s::Array{Sym}) = print(io, "\n", sympy["pretty"](convert(SymMatrix, s)))
 
 ## We add show methods for the REPL (text/plain) and IJulia (text/latex)
 
 ## text/plain
-@compat show(io::IO, ::MIME"text/plain", s::SymbolicObject) =  print(io, sympy[:pretty](project(s)))
-@compat show(io::IO, ::MIME"text/plain", s::Array{Sym}) =  print(io, summary(s), "\n", sympy[:pretty](convert(SymMatrix, s)))
+@compat show(io::IO, ::MIME"text/plain", s::SymbolicObject) =  print(io, sympy["pretty"](project(s)))
+@compat show(io::IO, ::MIME"text/plain", s::Array{Sym}) =  print(io, summary(s), "\n", sympy["pretty"](convert(SymMatrix, s)))
 
 @compat show(io::IO, ::MIME"text/latex", x::Sym) = print(io, latex(x, mode="equation*", itex=true))
 @compat function  show(io::IO, ::MIME"text/latex", x::Array{Sym})

--- a/src/dsolve.jl
+++ b/src/dsolve.jl
@@ -37,11 +37,11 @@ F,G,H = SymFunction("F, G, H")
 function SymFunction{T<:AbstractString}(x::T)
     us = split(x, r",\s*")
     if length(us) > 1
-        map(u -> SymFunction(sympy[:Function](u), 0), us)
+        map(u -> SymFunction(sympy["Function"](u), 0), us)
     else
-        SymFunction(sympy[:Function](x), 0)
+        SymFunction(sympy["Function"](x), 0)
     end
-#    u = sympy[:Function](x)
+#    u = sympy["Function"](x)
 #    SymFunction(u, 0)
 end
 
@@ -139,7 +139,7 @@ initial conditions 2) calling `solve` for the constants `C1`, `C2`,
 approach breaks down, then those steps can be done manually starting
 with the output of `dsolve` without the initial conditions.
 
-"""             
+"""
 
 dsolve(ex::Sym;kwargs...) = sympy_meth(:dsolve, ex; kwargs...)
 dsolve(exs::Vector{Sym};kwargs...) = sympy_meth(:dsolve, exs; kwargs...)
@@ -161,7 +161,7 @@ Specifying the function, as in `dsolve(ex, f(x))`, is deprecated.
 Use `sympy_meth(:dsolve, ex, f(x); kwargs...)` directly for that underlying interface.
 """))
     end
-    
+
     out = dsolve(eqn; kwargs...)
     ord = sympy_meth(:ode_order, eqn, var)
 
@@ -196,11 +196,11 @@ function _solve_ivp(out, var, args, o)
         if length(sols) == 1
             sols = sols[1]
         else
-            return [out([Pair(k,v) for (k,v) in sol]...) for sol in sols] 
+            return [out([Pair(k,v) for (k,v) in sol]...) for sol in sols]
         end
     end
 
-    out([Pair(k,v) for (k,v) in sols]...) 
+    out([Pair(k,v) for (k,v) in sols]...)
 end
 
 export SymFunction, symfunction, dsolve

--- a/src/integrate.jl
+++ b/src/integrate.jl
@@ -47,7 +47,7 @@ Dirac delta for integration
 
 [SymPy Documentation](http://docs.sympy.org/dev/modules/functions/special.html)
 """
-DiracDelta(x::Number) = convert(Function, sympy[:DiracDelta])(x)
+DiracDelta(x::Number) = pycall(sympy["DiracDelta"], PyAny, x)
 export DiracDelta
 
 """
@@ -57,7 +57,7 @@ Heaviside function for integration.
 
 [SymPy Documentation](http://docs.sympy.org/dev/modules/functions/special.html)
 """
-Heaviside(x::Number) = convert(Function, sympy[:Heaviside])(x)
+Heaviside(x::Number) = pycall(sympy["Heaviside"], PyAny, x)
 export Heaviside
 
 
@@ -93,4 +93,3 @@ summations_instance_methods  = (
                                 :euler_maclaurin,
                                 )
 summations_object_properties  = (:is_zero, :is_number)
-

--- a/src/math.jl
+++ b/src/math.jl
@@ -56,13 +56,13 @@ for fn in (:cosd, :cotd, :cscd, :secd, :sind, :tand,
           :acosd, :acotd, :acscd, :asecd, :asind, :atand)
 
     rad_fn = string(fn)[1:end-1]
-    @eval ($fn)(x::Sym) = sympy[@compat(Symbol($rad_fn))](project(x * Sym(sympy[:pi]/180)))
+    @eval ($fn)(x::Sym) = sympy[@compat(Symbol($rad_fn))](project(x * Sym(sympy["pi"])/180))
     @eval ($fn)(a::Array{Sym}) = map($fn, a)
 end
 
 for fn in (:cospi, :sinpi)
     rad_fn = string(fn)[1:end-2]
-    @eval ($fn)(x::Sym) = sympy[@compat(Symbol($rad_fn))](project(x * Sym(sympy[:pi])))
+    @eval ($fn)(x::Sym) = sympy[@compat(Symbol($rad_fn))](project(x * Sym(sympy["pi"])))
     @eval ($fn)(a::Array{Sym}) = map($fn, a)
 end
 
@@ -215,8 +215,8 @@ Base.isinf(x::Sym) = try isinf(convert(Float64, x)) catch e false end
 Base.isnan(x::Sym) = try isnan(convert(Float64, x)) catch e false end
 
 ## we rename sympy.div -> polydiv
-Base.div(x::Sym, y::SymOrNumber) = convert(Sym, sympy[:floor](x/convert(Sym,y)))
-Base.rem(x::Sym, y::SymOrNumber) = x-Sym(y)*Sym(sympy[:floor](x/y))
+Base.div(x::Sym, y::SymOrNumber) = convert(Sym, sympy["floor"](x/convert(Sym,y)))
+Base.rem(x::Sym, y::SymOrNumber) = x-Sym(y)*Sym(sympy["floor"](x/y))
 
 ## zero and one (zeros?)
 Base.zero(x::Sym) = Sym(0)
@@ -282,22 +282,22 @@ export Indicator, Χ
 ## special numbers are initialized after compilation
 function init_math()
     "PI is a symbolic  π. Using `julia`'s `pi` will give round off errors."
-    global const PI = Sym(sympy[:pi])
+    global const PI = Sym(sympy["pi"])
 
     "E is a symbolic  `e`. Using `julia`'s `e` will give round off errors."
-    global const E = Sym(sympy[:exp](1))
+    global const E = Sym(sympy["exp"](1))
 
     "IM is a symbolic `im`"
-    global const IM = Sym(sympy[:I])
+    global const IM = Sym(sympy["I"])
 
     "oo is a symbolic infinity. Example: `integrate(exp(-x), x, 0, oo)`."
-    global const oo = Sym(sympy[:oo])
+    global const oo = Sym(sympy["oo"])
 
 
     ## math constants
     Base.convert(::Type{Sym}, x::Irrational{:π}) = PI
     Base.convert(::Type{Sym}, x::Irrational{:e}) = E
-    Base.convert(::Type{Sym}, x::Irrational{:γ}) = sympy[:EulerGamma]
-    Base.convert(::Type{Sym}, x::Irrational{:catalan}) = sympy[:Catalan]
+    Base.convert(::Type{Sym}, x::Irrational{:γ}) = sympy["EulerGamma"]
+    Base.convert(::Type{Sym}, x::Irrational{:catalan}) = sympy["Catalan"]
     Base.convert(::Type{Sym}, x::Irrational{:φ}) = (1 + Sym(5)^(1//2))/2
 end

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -1,13 +1,13 @@
 ## evaluate binary operations of symbolic objects
 ## XXX -- this may prove too narryw with the use of ::Sym
-+(x::SymbolicObject, y::SymbolicObject) = pycall(sympy[:Add], Sym, x, y)
-*(x::SymbolicObject, y::SymbolicObject) = pycall(sympy[:Mul], Sym, x, y)
++(x::SymbolicObject, y::SymbolicObject) = pycall(sympy["Add"], Sym, x, y)
+*(x::SymbolicObject, y::SymbolicObject) = pycall(sympy["Mul"], Sym, x, y)
 -(x::SymbolicObject, y::SymbolicObject) = x + (-y)
--(x::SymbolicObject)                    =  (-1) * x 
-/(x::Sym, y::Sym) = x * pycall(sympy[:Pow], Sym, y, -1)::Sym 
+-(x::SymbolicObject)                    =  (-1) * x
+/(x::Sym, y::Sym) = x * pycall(sympy["Pow"], Sym, y, -1)::Sym
 ^(x::SymbolicObject, y::Rational) = x^convert(Sym,y)
 ^(x::SymbolicObject, y::Integer) = x^convert(Sym,y) # no Union{Integer, Rational}, as that has ambiguity
-^(x::Sym, y::Sym) = pycall(sympy[:Pow], Sym, x, y)::Sym      
+^(x::Sym, y::Sym) = pycall(sympy["Pow"], Sym, x, y)::Sym      
 //(x::SymbolicObject, y::Int) = x / Sym(y)
 //(x::SymbolicObject, y::Rational) = x / Sym(y)
 //(x::SymbolicObject, y::SymbolicObject) = x / y

--- a/src/patternmatch.jl
+++ b/src/patternmatch.jl
@@ -3,14 +3,14 @@
 """
     `Wild(:x)`: create a "wild card" for pattern matching
 """
-Wild(x::AbstractString) = convert(Function, sympy[:Wild])(x)
+Wild(x::AbstractString) = pycall(sympy["Wild"], PyAny, x)
 Wild(x::Symbol) = Wild(string(x))
 export Wild
 
 """
     `match(pattern, expression, ...)` match pattern against expression
 
-returns a dictionary of matches. 
+returns a dictionary of matches.
 
 If a match is unsuccesful, returns an *empty* dictionary. (SymPy returns "nothing")
 

--- a/src/physics.jl
+++ b/src/physics.jl
@@ -34,7 +34,7 @@ for (m, meths) in physics
             `$($meth_name)`: a SymPy function.
                 The SymPy documentation can be found through: http://docs.sympy.org/latest/search.html?q=$($meth_name)
                 """ ->
-            ($meth)(args...;kwargs...) = convert(Function, getindex($m, $meth_name))(map(Sym, args)..., map(Sym, kwargs)...)
+            ($meth)(args...;kwargs...) = pycall(getindex($m, $meth_name), PyAny, map(Sym, args)..., map(Sym, kwargs)...)
         end
         eval(Expr(:export, meth))
     end

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -31,13 +31,13 @@ Example:
 plot([sin(x), cos(x)], 0, 2pi)
 ```
 
-* `plot(ex1, ex2, a, b; kwargs...)` will plot the two expressions in a parametric plot over the interval `[a,b]`.   
+* `plot(ex1, ex2, a, b; kwargs...)` will plot the two expressions in a parametric plot over the interval `[a,b]`.
 
 Example:
 
 ```
 @vars x
-plot(sin(2x), cos(3x), 0, 4pi) ## also 
+plot(sin(2x), cos(3x), 0, 4pi) ## also
 ```
 
 For a few backends (those that support `:path3d`) a third symbolic
@@ -134,7 +134,7 @@ _lambdify(ex) = x -> N(ex(x))
 ## Not ready yet!
 ## @recipe function f(::Type{Val{:vectorfieldplot}}, fx, fy, xlim=(-5,5), ylim=(-5,5); n=15)
 
-    
+
 ##     x₀, x₁ = xlim
 ##     y₀, y₁ = ylim
 ##     Δx = (x₁ - x₀) / (n-1)
@@ -157,14 +157,14 @@ _lambdify(ex) = x -> N(ex(x))
 
 ##     XS = Float64[]
 ##     YS = Float64[]
-    
+
 ##     for x in xs, y in ys
 ##         append!(XS, [x, x + λ * fx(x,y), NaN])
 ##         append!(YS, [y, y + λ * fy(x,y), NaN])
 ##     end
 ##     pop!(XS); pop!(YS)
 
-    
+
 ##     seriestype := :path
 ##     xlims := xlim
 ##     ylims := ylim
@@ -232,8 +232,8 @@ function plot_parametric_surface(exs::(@compat Tuple{Sym,Sym,Sym}),
                                  args...;
                                  kwargs...)
 
-    SymPy.call_sympy_fun(sympy[:plotting][:plot3d_parametric_surface], exs..., args...; kwargs...)
-    
+    SymPy.call_sympy_fun(sympy["plotting"]["plot3d_parametric_surface"], exs..., args...; kwargs...)
+
 end
 export plot_parametric_surface
 
@@ -250,5 +250,5 @@ plot_implicit(Eq(x^2+ y^2,3), (x, -2, 2), (y, -2, 2))
 ```
 
 """
-plot_implicit(ex, args...; kwargs...) = SymPy.call_sympy_fun(sympy[:plotting][:plot_implicit], ex, args...; kwargs...)
+plot_implicit(ex, args...; kwargs...) = SymPy.call_sympy_fun(sympy["plotting"]["plot_implicit"], ex, args...; kwargs...)
 export plot_implicit

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -32,7 +32,7 @@ polydiv(ex::Sym, args...; kwargs...) = sympy_meth(:div, ex, args...; kwargs...)
 
 """
 
-Polynomial division remainer. 
+Polynomial division remainer.
 
 """
 
@@ -141,7 +141,7 @@ coeffs(p)  ## [a,b,c]
 ```
 
 """
-Poly(x::Sym) = sympy[:Poly](x)
+Poly(x::Sym) = sympy["Poly"](x)
 Poly(x::Sym, args...; kwargs...) = sympy_meth(:Poly, x, args...; kwargs...)
 export Poly
 

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -51,13 +51,13 @@ sypmy_sets = nothing
 module S
 using SymPy
 function init_set()
-    S = sympy[:S]
-    global Reals = S[:Reals]
-    global UniversalSet = S[:UniversalSet]
-    global Naturals = S[:Naturals]
-    global Naturals0 = S[:Naturals0]
-    global Integers = S[:Integers]
-    global EmptySet = S[:EmptySet]
+    S = sympy["S"]
+    global Reals = S["Reals"]
+    global UniversalSet = S["UniversalSet"]
+    global Naturals = S["Naturals"]
+    global Naturals0 = S["Naturals0"]
+    global Integers = S["Integers"]
+    global EmptySet = S["EmptySet"]
 end
 end
 
@@ -91,7 +91,7 @@ function _union_to_intervals(s::Sym)
     is_Union(s) || throw(ArgumentError("`s` must be a Union of Intervals"))
     collect(args(s))
 end
-                         
+
 
 
 "Find power set of set"
@@ -104,8 +104,7 @@ Base.contains(I::Sym, x) = (I[:contains](x) == Sym(true))
 Base.in(x::Number, I::Sym) = contains(I, x)
 
 "Elements of finite set"
-#elements(x::Sym) = (s = project(x); PyCall.py"[i for i in $s]o")
-elements(x::Sym) = (s = project(x); PyCall.pyeval("[i for i in s]", s=s))
+elements(x::Sym) = collect(project(x))
 export elements
 
 
@@ -113,7 +112,7 @@ VERSION < v"0.5.0-" && eval(Expr(:import, :Base, :complement))
 "Complement of set within the universe"
 complement(I::Sym, U::Sym=S.Reals) = I[:complement](U)
 export complement
-    
+
 "boundary, returnsa set"
 boundary(I::Sym) = I.x[:boundary]
 
@@ -209,7 +208,7 @@ See also `Interval` to create subsets of the real line.
     """
     Represent a ComplexRegion.
     working?
-```    
+```
     I, J = Interval(0,1), Interval(0,2)
     R = ComplexRegion(I * J)
     1 in R        # true
@@ -217,7 +216,7 @@ See also `Interval` to create subsets of the real line.
 ```
 """
     ComplexRegion(IJ::Sym; kwargs...) = sympy_meth(:ComplexRegion, IJ; kwargs...)
-    
+
     "imageset: http://docs.sympy.org/latest/modules/sets.html"
     global imageset(fn::Function, args...) = begin
         x = Sym("x")
@@ -225,9 +224,9 @@ See also `Interval` to create subsets of the real line.
     end
     global imageset(args...) = sympy_meth(:imageset, args...)
 
-    
+
     ## Interval
-    
+
 """
 Create an interval object
 
@@ -239,5 +238,5 @@ Interval(0,1,true, false) # (0,1]
 """
     global Interval(l,r,left_open=false, right_open=false) = sympy_meth(:Interval, Sym(l), Sym(r), left_open ,right_open)
 
-    
+
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -2,7 +2,7 @@
 
 Solve an expression for any zeros or a system of expressions passed a vector.
 
-Examples: 
+Examples:
 
 ```
 x,y, a,b,c = symbols("x, y, a, b, c", real=true)
@@ -28,18 +28,18 @@ The `SymPy` docs say this about `solve`:
 > cannot be represented symbolically. For example, the equation
 > `x=cos(x)` has a solution, but it cannot be represented
 > symbolically using standard functions.
-> 
+>
 > In fact, solve makes no guarantees whatsoever about the completeness
 > of the solutions it finds. Much of solve is heuristics, which may find
 > some solutions to an equation or system of equations, but not all of
 > them.
-        
+
 
 The return value depends on the inputs:
 
 * If there is one equation with one specified variable (either explicit, or because `free_symbols` returns only one variable), the return value is an array of solutions.
 
-* Otherwise, if there is a unique solution found a dictionary is returned. 
+* Otherwise, if there is a unique solution found a dictionary is returned.
 
 * Otherwise, if there is 0 or more than one solution found, an array of dictionaries is returned.
 
@@ -49,11 +49,11 @@ Note: The individual components of the array display more nicely than the array.
 
 Reference: [SymPy Docs](http://docs.sympy.org/0.7.5/modules/solvers/solvers.html#algebraic-equations)
 
-"""  
+"""
 function solve{T<:Sym}(ex::(@compat Union{T,Vector{T}});  kwargs...)
     ## No symbols specified? Find them
     xs = free_symbols(ex)
-    if length(xs) ==0 
+    if length(xs) ==0
         error("The expression has non free variables")
     elseif length(xs) == 1
         xs = xs[1]
@@ -64,7 +64,7 @@ end
 ## solve for a single variable, Return Sym[]
 function solve(ex::Sym, x::Sym; kwargs...)
     a = sympy_meth(:solve, ex, x;  kwargs...)
-    
+
     ## Way too much work here to finesse into a nice enough output
     ## (Issue comes from solving without specifying variable when 2 or more variables in the expression
     isa(a, Dict) && return(a)
@@ -114,7 +114,7 @@ end
 """
 Numerically solve for a zero of an expression.
 
-Examples: 
+Examples:
 ```
 solve(x^5 - x -1) # inconclusive
 nsolve(x^5 - x - 1, 1)
@@ -123,13 +123,13 @@ nsolve(x^5 - x - 1, 1)
 Returns symbolic values. Use `N`, or some other means, to convert to floating point.
 
 Reference: [SymPy Docs](http://docs.sympy.org/0.7.5/modules/solvers/solvers.html#algebraic-equations)
-"""              
+"""
 nsolve(ex::Sym, x::Sym, x0::Number) = sympy_meth(:nsolve, project(ex), project(x), x0)
 nsolve(ex::Sym, x0::Number) =  sympy_meth(:nsolve, project(ex), x0) |> x -> convert(Float64, x)
 function nsolve{T <: Number}(ex::Vector{Sym}, x::Vector{Sym}, x0::Vector{T}; kwargs...)
     out = sympy_meth(:nsolve, tuple(map(project,ex)...), tuple(map(project,x)...), tuple(x0...); kwargs...)
     ## ans is matrix object -- convert
-    convert(Array{Sym}, sympy[:Matrix](out))
+    convert(Array{Sym}, sympy["Matrix"](out))
 end
 export nsolve
 
@@ -140,7 +140,7 @@ export nsolve
 function solveset{T<:Sym}(ex::(@compat Union{T,Vector{T}});  kwargs...)
     ## No symbols specified? Find them
     xs = free_symbols(ex)
-    if length(xs) ==0 
+    if length(xs) ==0
         error("The expression has non free variables")
     elseif length(xs) == 1
         xs = xs[1]

--- a/src/types.jl
+++ b/src/types.jl
@@ -46,7 +46,7 @@ typealias SymbolicTypes  @compat Union{AbstractString, Symbol, SymbolicObject}
 
 PyCall.PyObject(x::SymbolicObject) = x.x
 
-## Promotion 
+## Promotion
 ## promote up to symbolic so that math ops work
 promote_rule{T<:SymbolicObject, S<:Number}(::Type{T}, ::Type{S} ) = T
 
@@ -77,7 +77,7 @@ convert{T <: Real}(::Type{T}, x::Sym) = convert(T, project(x))
 
 
 ## complex
-## IM is SymPy's "i" (sympy[:I], not Python's
+## IM is SymPy's "i" (sympy["I"], not Python's
 ## Sym(PyCall.PyObject(im)) which gives 1j.
 function convert(::Type{Sym}, x::Complex)
     y = ifelse(isa(x, Complex{Bool}), real(x) + imag(x) * im, x)
@@ -102,7 +102,7 @@ convert(::Type{Sym}, o::Symbol) = sympy_meth(:sympify, string(o))
 Get the free symbols in a more convenient form than as returned by `free_symbols`.
 
 Just `free_symbols` now does the same thing. This function will be deprecated.
-"""    
+"""
 function get_free_symbols(ex::Sym)
     free = free_symbols(ex)
     n = free[:__len__]()


### PR DESCRIPTION
As discussed in #83, this eliminates things like `pyeval` (which is deprecated) and `convert(Function, o)(...)` in favor of the `PyCall.pycall` function.

Also, it changes things like `sympy[:foo]` to `sympy["foo"]` when a `PyObject` result is expected.  This avoids the overhead of PyCall trying (unsuccessfully) to figure out whether the object can be converted to any native Julia type, and is also type-stable.

As mentioned in #83, I think you should also mostly eliminate the `project(x::T)` function in favor of adding new `PyObject(x::T)` constructors, and also `pycall(x::T, ...) = pycall(PyObject(x), ...)`.