### PR TITLE
updates for recent v0.6 changes: special funs, type

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
-Compat 0.9.0
+Compat 0.17.0
 PyCall 1.6.0
 RecipesBase 0.0.4
 BaseTestNext 0.2.2

--- a/src/series.jl
+++ b/src/series.jl
@@ -9,7 +9,13 @@ series_sympy_meths = (#:limit
                       :fourier_series
                       )
 
-import Base: scale, truncate
+import Base: truncate
+
+if VERSION < v"0.6.0-dev"
+    eval(Expr(:import, :Base, :scale))
+else
+     eval(Expr(:export, :scale))
+end
 series_object_meths_base = (:truncate,
                             )
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -104,7 +104,7 @@ function solve{T<:Sym,S<:Sym}(exs::(@compat Union{T,Vector{T}}), xs::Vector{S}; 
     if isa(a, Dict)
         _mapdict(a)              # XXX type unstable! should be array... Should we change? XXX
     else
-        [_mapdict(_,xs) for _ in a]
+        [_mapdict(_underscore,xs) for _underscore in a]
     end
 end
 

--- a/src/specialfuns.jl
+++ b/src/specialfuns.jl
@@ -3,9 +3,20 @@ module SpecialFuncs
 using PyCall
 using SymPy
 
-import Base: gamma, polygamma, beta,
-             airyai, airybi,
-             besseli, besselj, besselk, bessely
+if VERSION < v"0.6.0-dev"
+    import Base: gamma, polygamma, beta,
+           airyai, airybi,
+           besseli, besselj, besselk, bessely
+else
+    ## how to handlethis deprecation phase without SpecialFuncs.jl, as that
+    ## doesn't have v0.4 support?
+    ## Here we need to qualify usage, as in `SpecialFuns.airyai`.
+    for meth in  (:gamma, :polygamma, :beta,
+               :airyai, :airybi,
+               :besseli, :besselj, :besselk, :bessely)
+        eval(Expr(:export, meth))
+    end
+end
 
 for meth in (
              :jacobi,

--- a/src/types.jl
+++ b/src/types.jl
@@ -2,7 +2,7 @@
 
 
 ## Symbol class for controlling dispatch
-abstract SymbolicObject <: Number
+@compat abstract type SymbolicObject <: Number end
 
 ## Basic types defined here
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,7 @@ include("test-math.jl")
 include("test-matrix.jl")
 include("test-ode.jl")
 include("test-logical.jl")
-include("test-specialfuncs.jl")
+if VERSION < v"0.6.0-dev"
+    include("test-specialfuncs.jl")
+end
 include("test-physics.jl")

--- a/test/test-specialfuncs.jl
+++ b/test/test-specialfuncs.jl
@@ -159,11 +159,12 @@ end
 
 
     # test numerical consistency with Julia functions
-    @test N(besselj(3.2, Sym(1.5))) ≈ besselj(3.2, 1.5)
-    @test N(bessely(3.2, Sym(1.5))) ≈ bessely(3.2, 1.5)
-    @test N(besseli(3.2, Sym(1.5))) ≈ besseli(3.2, 1.5)
-    @test N(besselk(3.2, Sym(1.5))) ≈ besselk(3.2, 1.5)
-
+    if VERSION < v"0.6.0-dev"
+      @test N(besselj(3.2, Sym(1.5))) ≈ besselj(3.2, 1.5)
+      @test N(bessely(3.2, Sym(1.5))) ≈ bessely(3.2, 1.5)
+      @test N(besseli(3.2, Sym(1.5))) ≈ besseli(3.2, 1.5)
+      @test N(besselk(3.2, Sym(1.5))) ≈ besselk(3.2, 1.5)
+    end
 
     @test expand_func(x*hyper([1, 1], [2], -x)) == log(x + 1)
 end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -288,11 +288,7 @@ end
     @test_throws DimensionOrMethodError   v * v ## error
     @test v .* v == [x^2,1]
     @test dot(v, v) == 1 + conj(x)*x
-    if VERSION >= v"0.6.0-dev"
-        @test_throws DimensionMismatch v * rv ## 2x1 1x2 == 2x2
-    else
-        v * rv
-    end
+    v * rv
     rv * v ## 1x2 2 x 1 == 1x1
     v .* rv ## XXX ?? should be what? -- not 2 x 2
     rv .* v ## XXX ditto


### PR DESCRIPTION
This updates for changes to abstract type definitions.

In addition, it works around changes to special functions being moved to a package. @mzaffalon I'm not sure how best to do this without stopping support for v0.4. Any thoughts? This approach requires qualification (e.g. `SpecialFuns.besselk`) until the deprecation phase is done and I've turned off testing in v0.6, though if qualification seems right, I will add and turn testing back on.