### PR TITLE
Make things work for `AbstractArray`, not just `Array`

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -8,7 +8,7 @@ doc(x::SymbolicObject) = print(x[:__doc__])
 _str(s::SymbolicObject) = s[:__str__]()
 
 "Map an array of symbolic objects to a string"
-_str(a::Array{SymbolicObject}) = map(_str, a)
+_str(a::AbstractArray{SymbolicObject}) = map(_str, a)
 
 "call SymPy's pretty print"
 pprint(s::SymbolicObject, args...; kwargs...) = sympy_meth(:pprint, s, args...; kwargs...)
@@ -24,26 +24,26 @@ function jprint(x::SymbolicObject)
     end
     out
 end
-jprint(x::Array) = map(jprint, x)
+jprint(x::AbstractArray) = map(jprint, x)
 
 ## show is called in printing tuples, ...
 ## we would like to use pprint here, but it does a poor job on complicated multi-line expressions
 Base.show(io::IO, s::Sym) = print(io, jprint(s))
-Base.show(io::IO, s::Array{Sym}) = print(io, "\n", sympy_meth(:pretty, s))
+Base.show(io::IO, s::AbstractArray{Sym}) = print(io, "\n", sympy_meth(:pretty, s))
 
 ## We add show methods for the REPL (text/plain) and IJulia (text/latex)
 
 ## text/plain
 @compat show(io::IO, ::MIME"text/plain", s::SymbolicObject) =  print(io, sympy["pretty"](s))
-@compat show(io::IO, ::MIME"text/plain", s::Array{Sym}) =  print(io, summary(s), "\n", sympy_meth(:pretty, s))
+@compat show(io::IO, ::MIME"text/plain", s::AbstractArray{Sym}) =  print(io, summary(s), "\n", sympy_meth(:pretty, s))
 
 @compat show(io::IO, ::MIME"text/latex", x::Sym) = print(io, latex(x, mode="equation*", itex=true))
-@compat function  show(io::IO, ::MIME"text/latex", x::Array{Sym})
+@compat function  show(io::IO, ::MIME"text/latex", x::AbstractArray{Sym})
     function toeqnarray(x::Vector{Sym})
         a = join([latex(x[i]) for i in 1:length(x)], "\\\\")
         "\\begin{bmatrix}$a\\end{bmatrix}"
     end
-    function toeqnarray(x::Array{Sym,2})
+    function toeqnarray(x::AbstractArray{Sym,2})
         sz = size(x)
         a = join([join(map(latex, x[i,:]), "&") for i in 1:sz[1]], "\\\\")
         "\\begin{bmatrix}$a\\end{bmatrix}"

--- a/src/math.jl
+++ b/src/math.jl
@@ -38,13 +38,13 @@ for fn in (:cosd, :cotd, :cscd, :secd, :sind, :tand,
 
     rad_fn = string(fn)[1:end-1]
     @eval ($fn)(x::Sym) = sympy[@compat(Symbol($rad_fn))](x * Sym(sympy["pi"])/180)
-    @eval ($fn)(a::Array{Sym}) = map($fn, a)
+    @eval ($fn)(a::AbstractArray{Sym}) = map($fn, a)
 end
 
 for fn in (:cospi, :sinpi)
     rad_fn = string(fn)[1:end-2]
     @eval ($fn)(x::Sym) = sympy[@compat(Symbol($rad_fn))](x * Sym(sympy["pi"]))
-    @eval ($fn)(a::Array{Sym}) = map($fn, a)
+    @eval ($fn)(a::AbstractArray{Sym}) = map($fn, a)
 end
 
 ## :asech, :acsch, :sinc, :cosc,
@@ -58,10 +58,10 @@ sinc(x::Sym) = piecewise((Sym(1), Eq(x, 0)), (sin(PI*x)/(PI*x), Gt(abs(x), 0)))
 cosc(x::Sym) = diff(sinc(x))
 
 # deprecate these when v0.4 support dropped in favor of `asech.(...)` form
-asech(as::Array{Sym}) = map(asech, as)
-acsch(as::Array{Sym}) = map(acsch, as)
-sinc(as::Array{Sym}) = map(sinc, as)
-cosc(as::Array{Sym}) = map(cosc, as)
+asech(as::AbstractArray{Sym}) = map(asech, as)
+acsch(as::AbstractArray{Sym}) = map(acsch, as)
+sinc(as::AbstractArray{Sym}) = map(sinc, as)
+cosc(as::AbstractArray{Sym}) = map(cosc, as)
 
 
 ## in Julia, not SymPy
@@ -78,7 +78,7 @@ functions_sympy_methods = (
 
 ## map Abs->abs, Max->max, Min->min
 abs(ex::Sym, args...; kwargs...) = sympy_meth(:Abs, ex, args...; kwargs...)
-abs(a::Array{Sym}) = map(abs, a)
+abs(a::AbstractArray{Sym}) = map(abs, a)
 Base.abs2(x::Sym) = re(x*conj(x))
 Base.copysign(x::Sym, y::Sym) = abs(x)*sign(y)
 Base.signbit(x::Sym) = x < 0
@@ -150,7 +150,8 @@ end
 
 
 ## diff for matrix doesn't handle vectors well, so we vectorize here
-diff(exs::Array{Sym}, args...; kwargs...) = map(ex -> diff(ex, args...;kwargs...), exs)
+diff(exs::AbstractVector{Sym}, args...; kwargs...) = map(ex -> diff(ex, args...;kwargs...), exs)
+diff(exs::AbstractMatrix{Sym}, args...; kwargs...) = map(ex -> diff(ex, args...;kwargs...), exs)
 
 ## find symbolic derivatives from a function
 function diff(f::Function, k::Int=1; kwargs...)
@@ -200,7 +201,7 @@ Indicator expression: (Either `\Chi[tab](x,a,b)` or `Indicator(x,a,b)`)
 
 
 This is not a function taking `x`, but a symbolic expression of `x`.
-    
+
 """
 Χ(x::Sym, a=-oo, b=oo) = piecewise((1, Gt(x, a) ∧ Le(x, b)), (0,true))
 Indicator(x::Sym, a=-oo, b=oo) = Χ(x, a, b)

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -5,14 +5,14 @@
 ## this is achieved with the convert(Array{Sym}, o::PyObject) method below.
 
 ## Array{Sym} objects are converted into Python objects via
-PyCall.PyObject(a::Array{Sym}) = pycall(sympy[:Matrix], PyObject, PyCall.array2py(a))
+PyCall.PyObject(a::AbstractArray{Sym}) = pycall(sympy[:Matrix], PyObject, PyCall.array2py(a))
 
 ## Matrix methods and objects
 
 
 ## For calling methods we have  call_matrix_meth(M, :meth, ...) for M.meth(...)
 ## This helps, grabbing the M.meth part
-function getindex(s::Array{Sym}, i::Symbol)
+function getindex(s::AbstractArray{Sym}, i::Symbol)
     PyObject(s)[i]
 end
 
@@ -67,7 +67,7 @@ end
 
 ## covert back to Array{Sym}. Could just use broadcast (subs.(...)) here
 ## once v0.4 support is dropped.
-subs(ex::Array{Sym}, args...; kwargs...) = map(u -> subs(u, args...; kwargs...), ex)
+subs(ex::AbstractArray{Sym}, args...; kwargs...) = map(u -> subs(u, args...; kwargs...), ex)
 
 
 ## Methods
@@ -134,7 +134,7 @@ end
 
 
 cofactor(A::Matrix{Sym}, i, j) = call_matrix_meth(A, :cofactor, i-1, j-1)
-jacobian(X::Array{Sym}, Y::Array{Sym}) = call_matrix_meth(X, :jacobian, Y)
+jacobian(X::AbstractArray{Sym}, Y::AbstractArray{Sym}) = call_matrix_meth(X, :jacobian, Y)
 
 export cofactor
 
@@ -159,7 +159,8 @@ end
 
 
 ## These are special cased
-norm(a::Array{Sym}, args...; kwargs...) = call_matrix_meth(a, :norm, args...; kwargs...)
+norm(a::AbstractVector{Sym}, args...; kwargs...) = call_matrix_meth(a, :norm, args...; kwargs...)
+norm(a::AbstractMatrix{Sym}, args...; kwargs...) = call_matrix_meth(a, :norm, args...; kwargs...)
 chol(a::Matrix{Sym}) = cholesky(a)
 expm(a::Matrix{Sym}) = call_matrix_meth(a, :exp)
 conj(a::Sym) = conjugate(a)
@@ -202,7 +203,7 @@ u = SymFunction("u")(x,y)
 hessian(u, [x,y])
 ```
 """
-hessian(u::SymbolicObject, vars::Array{Sym}, args...) = sympy_meth(:hessian, u, vars, args...)
+hessian(u::SymbolicObject, vars::AbstractArray{Sym}, args...) = sympy_meth(:hessian, u, vars, args...)
 hessian(u::SymbolicObject) = hessian(u, free_symbols(u))
 
 

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -35,7 +35,7 @@ cse(((w + x + y + z)*(w + y + z))/(w + x)^3), ([(x0, y + z), (x1, w + x)], [(w +
 cse{T<:SymbolicObject}(ex::T, args...; kwargs...) = sympy_meth(:cse, ex, args...; kwargs...)
 cse{T<:SymbolicObject}(ex::Vector{T}, args...; kwargs...) = sympy_meth(:cse, ex, args...; kwargs...)
         
-function cse{T<:SymbolicObject, N}(ex::Array{T, N}, args...; kwargs...)
+function cse{T<:SymbolicObject, N}(ex::AbstractArray{T, N}, args...; kwargs...)
     a,b = cse(ex[:], args...; kwargs...)
     bb = convert(Array{Sym},  reshape(b, size(ex)))
     a, bb

--- a/src/specialfuns.jl
+++ b/src/specialfuns.jl
@@ -36,7 +36,7 @@ for fn in (:besselj, :bessely, :besseli, :besselk)
     meth = string(fn)
 #    eval(Expr(:import, :Base, fn))
     @eval ($fn)(nu::Number, x::Sym; kwargs...) = sympy_meth($meth, nu, x; kwargs...)
-    @eval ($fn)(nu::Number, a::Array{Sym}) = map(x ->$fn(nu, x), a)
+    @eval ($fn)(nu::Number, a::AbstractArray{Sym}) = map(x ->$fn(nu, x), a)
 end
 
 
@@ -52,7 +52,7 @@ The SymPy documentation can be found through: http://docs.sympy.org/latest/searc
 """ ->
         ($meth)(x::Sym;kwargs...) = sympy_meth($meth_name, x; kwargs...)
     end
-    @eval ($meth)(a::Array{Sym}) = map($meth, a)
+    @eval ($meth)(a::AbstractArray{Sym}) = map($meth, a)
     eval(Expr(:export, meth))
 end
 

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -147,7 +147,7 @@ function N(ex::Sym)
     throw(DomainError())
 end
 N(x::Number) = x
-N(m::Array{Sym}) = map(N, m)
+N(m::AbstractArray{Sym}) = map(N, m)
 """
 `N` can take a precision argument. 
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -81,7 +81,7 @@ function convert(::Type{Sym}, x::Complex)
 end
 convert(::Type{Complex}, x::Sym) = complex(map(x -> convert(Float64, x), x[:as_real_imag]())...)::Sym
 complex(x::Sym) = convert(Complex, x)
-complex(xs::Array{Sym}) = map(complex, xs)
+complex(xs::AbstractArray{Sym}) = map(complex, xs)
 
 ## string
 convert(::Type{Sym}, o::AbstractString) = sympy_meth(:sympify, o)

--- a/test/test-matrix.jl
+++ b/test/test-matrix.jl
@@ -36,12 +36,15 @@ end
     s = LUsolve(A, v)
     @test @compat simplify.(A * s) == v
 
-    # test norm
+    # norm
     @test norm(A) == sqrt(2 * abs(x)^2 + 2)
-
     # test norm for different subtypes of AbstractArray
     @test norm(A) == norm(Symmetric(A))
     @test norm(A) == norm(view(A, :, :))
+
+    # abs
+    @test all(abs(A) .>= 0)
+    @test abs(A) == abs(view(A, :, :))
 
     # is_lower, is_square, is_symmetric much slower than julia only counterparts. May deprecate, but for now they are here
     @test is_lower(A) == istril(A)
@@ -120,6 +123,6 @@ end
     X = [ρ*cos(ϕ), ρ*sin(ϕ)]
     @test jacobian(X, Y) == [cos(ϕ) -ρ*sin(ϕ);
                              sin(ϕ)  ρ*cos(ϕ)]
-
+    @test jacobian(X, Y) == jacobian(view(X, :), view(Y, :))
 
 end

--- a/test/test-matrix.jl
+++ b/test/test-matrix.jl
@@ -1,5 +1,6 @@
 using SymPy
 using Compat
+import Compat.view
 if VERSION >= v"0.5.0-dev+7720"
     using Base.Test
 else

--- a/test/test-matrix.jl
+++ b/test/test-matrix.jl
@@ -36,6 +36,12 @@ end
     s = LUsolve(A, v)
     @test @compat simplify.(A * s) == v
 
+    # test norm
+    @test norm(A) == sqrt(2 * abs(x)^2 + 2)
+
+    # test norm for different subtypes of AbstractArray
+    @test norm(A) == norm(Symmetric(A))
+    @test norm(A) == norm(view(A, :, :))
 
     # is_lower, is_square, is_symmetric much slower than julia only counterparts. May deprecate, but for now they are here
     @test is_lower(A) == istril(A)


### PR DESCRIPTION
I noticed that for `A::Matrix{Sym}`, `view(A, :, :)` doesn't print the same way as just `A` due to overly restrictive `Base.show` method signatures, and then saw that there are some additional cases.

I basically changed all `::Array`s to `::AbstractArray`s and then fixed the method ambiguity errors that arose due to `diff` and `norm` in `Base` only being defined for `AbstractVector` and `AbstractMatrix`, as oposed to for `AbstractArray`s of any dimension.