### PR TITLE
Fix infinite loop bug in “N” call on symbols

### DIFF
--- a/src/subs.jl
+++ b/src/subs.jl
@@ -140,7 +140,12 @@ function N(ex::Sym)
     ## more work than I'd like
     ## XXX consolidate this and N(ex, digits)
     if is_integer(ex) == nothing
-        return(N(ex[:evalf]()))
+        evalf_ex = ex[:evalf]()
+        if ex == evalf_ex
+            return ex
+        else
+            return N(evalf_ex)
+        end
     end
     if is_integer(ex)
         for T in [Int, BigInt]

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -132,6 +132,7 @@ end
     @test isa(N(p), Float64)
     @test isa(N(p, 60), BigFloat)
     @test isa(evalf(p), Sym)
+    @test isa(N(x), Sym)
     @test isa(N(q), Rational)
     @test isa(N(r), Float64)
     @test isa(N(z), Integer)


### PR DESCRIPTION
resolves: https://github.com/JuliaPy/SymPy.jl/issues/166

---------

notes:

+ actually more robust then proposed fix in issue
+ this is because the method looks like it tries to avoid errors