### PR TITLE
move around files for precompile, julia_code removal

### DIFF
--- a/src/lambdify.jl
+++ b/src/lambdify.jl
@@ -156,8 +156,10 @@ end
 export(lambdify)
 
 function init_lambdify()
-    if haskey(sympy, :julia_code)
-        global julia_code(ex::Sym; assign_to=nothing, kwargs...) = sympy_meth(:julia_code, ex; assign_to=assign_to, kwargs...)
-        eval(Expr(:export, :julia_code))
-    end
+#    if haskey(sympy, :julia_code)
+#        global julia_code(ex::Sym; assign_to=nothing, kwargs...) = sympy_meth(:julia_code, ex; assign_to=assign_to, kwargs...)
+#        julia_code(ex::Sym; assign_to=nothing, kwargs...) = sympy_meth(:julia_code, ex; assign_to=assign_to, kwargs...)
+#        eval(Expr(:export, :julia_code))
+#    end
 end
+

--- a/src/math.jl
+++ b/src/math.jl
@@ -237,24 +237,32 @@ Base.typemin(::Type{Sym}) = -oo
 
 ##################################################
 ## special numbers are initialized after compilation
+if isdefined(PyCall,:PyNULL)
+    pynull() = PyCall.PyNULL()
+else
+    pynull() = PyCall.PyObject()
+end
+global PI = Sym(pynull())
+global E = Sym(pynull())
+global IM = Sym(pynull())
+global oo = Sym(pynull())
+
+Base.convert(::Type{Sym}, x::Irrational{:π}) = PI
+Base.convert(::Type{Sym}, x::Irrational{:e}) = E
+Base.convert(::Type{Sym}, x::Irrational{:γ}) = Sym(sympy["EulerGamma"])
+Base.convert(::Type{Sym}, x::Irrational{:catalan}) = Sym(sympy["Catalan"])
+Base.convert(::Type{Sym}, x::Irrational{:φ}) = (1 + Sym(5)^(1//2))/2
+
 function init_math()
     "PI is a symbolic  π. Using `julia`'s `pi` will give round off errors."
-    global const PI = Sym(sympy["pi"])
+    copy!(PI.x,  sympy["pi"])
 
     "E is a symbolic  `e`. Using `julia`'s `e` will give round off errors."
-    global const E = Sym(sympy["exp"](1))
+    copy!(E.x, Sym(sympy["exp"](1)).x)
 
     "IM is a symbolic `im`"
-    global const IM = Sym(sympy["I"])
+    copy!(IM.x, sympy["I"])
 
     "oo is a symbolic infinity. Example: `integrate(exp(-x), x, 0, oo)`."
-    global const oo = Sym(sympy["oo"])
-
-
-    ## math constants
-    Base.convert(::Type{Sym}, x::Irrational{:π}) = PI
-    Base.convert(::Type{Sym}, x::Irrational{:e}) = E
-    Base.convert(::Type{Sym}, x::Irrational{:γ}) = Sym(sympy["EulerGamma"])
-    Base.convert(::Type{Sym}, x::Irrational{:catalan}) = Sym(sympy["Catalan"])
-    Base.convert(::Type{Sym}, x::Irrational{:φ}) = (1 + Sym(5)^(1//2))/2
+    copy!(oo.x, sympy["oo"])
 end

--- a/src/mpmath.jl
+++ b/src/mpmath.jl
@@ -36,7 +36,7 @@ end
 
 ## Call a function in the mpmath module, giving warning and returning NaN if module is not found
 ## (Doesn't need to be in init_mpmath?)
-global const mpmath_meth(meth, args...; kwargs...) = begin
+function mpmath_meth(meth, args...; kwargs...) 
     if isa(mpmath, Void)
         warn("The mpmath module of Python is not installed. http://docs.sympy.org/dev/modules/mpmath/setup.html#download-and-installation")
         return(Sym(NaN))

--- a/src/mpmath.jl
+++ b/src/mpmath.jl
@@ -34,6 +34,23 @@ for fn in mpmath_fns
     eval(Expr(:export, fn))
 end
 
+## Call a function in the mpmath module, giving warning and returning NaN if module is not found
+## (Doesn't need to be in init_mpmath?)
+global const mpmath_meth(meth, args...; kwargs...) = begin
+    if isa(mpmath, Void)
+        warn("The mpmath module of Python is not installed. http://docs.sympy.org/dev/modules/mpmath/setup.html#download-and-installation")
+        return(Sym(NaN))
+    end
+    
+    fn = mpmath[@compat(Symbol(meth))]
+    ans = call_sympy_fun(fn, args...; kwargs...)
+    ## make nicer...
+    if isa(ans, Vector)
+        ans = convert(Vector{Sym}, ans)
+    end
+    ans
+end
+
 ## Initialize mpmath
 ## includes trying to find the module!
 ## automatic mappings may throw warning about strings, though it is expected these
@@ -54,19 +71,5 @@ function init_mpmath()
         pytype_mapping(mpctype, Complex{BigFloat})
     end
 
-    ## Call a function in the mpmath module, giving warning and returning NaN if module is not found 
-    global mpmath_meth(meth, args...; kwargs...) = begin
-        if isa(mpmath, Void)
-            warn("The mpmath module of Python is not installed. http://docs.sympy.org/dev/modules/mpmath/setup.html#download-and-installation")
-            return(Sym(NaN))
-        end
-
-        fn = mpmath[@compat(Symbol(meth))]
-        ans = call_sympy_fun(fn, args...; kwargs...)
-        ## make nicer...
-        if isa(ans, Vector)
-            ans = convert(Vector{Sym}, ans)
-        end
-        ans
-    end
 end
+

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -65,10 +65,9 @@ end
 export S, FiniteSet, Interval, ProductSet, ConditionSet
 export powerset, imageset
 export contains,  boundary, sup, measure
+export as_relational
 export is_disjoint
 export is_proper_subset, is_subset, is_superset
-export Interval
-export as_relational
 export is_left_unbounded, is_right_unbounded, left_open, right_open
 export is_FiniteSet, is_Union, is_Interval
 
@@ -181,21 +180,20 @@ is_Union(I::Sym) = PyObject(I)[:is_Union]
 
 function init_sets()
     S.init_set()
-
+end  
 """
     `FiniteSet(1,2,3)`, `FiniteSet(1:10...)`: create a finite set
 
 See also `Interval` to create subsets of the real line.
 """
-    "FiniteSet: http://docs.sympy.org/latest/modules/sets.html"
-    global FiniteSet(args...) = sympy_meth(:FiniteSet, args...)
+FiniteSet(args...) = sympy_meth(:FiniteSet, args...)
 
-    "ProductSet: http://docs.sympy.org/latest/modules/sets.html"
-    global ProductSet(args...) = sympy_meth(:ProductSet, args...)
+"ProductSet: http://docs.sympy.org/latest/modules/sets.html"
+global ProductSet(args...) = sympy_meth(:ProductSet, args...)
 
-    """
+"""
     Means to filter a set to pull out elements by a condition.
-
+    
     ConditionSet:  A set of elements which satisfies a given condition.
 
     `ConditionSet(x, condition, S) = {x | condition(x) == true for x in S}`
@@ -215,17 +213,17 @@ See also `Interval` to create subsets of the real line.
     2 + 1im in R  # false
 ```
 """
-    ComplexRegion(IJ::Sym; kwargs...) = sympy_meth(:ComplexRegion, IJ; kwargs...)
+ComplexRegion(IJ::Sym; kwargs...) = sympy_meth(:ComplexRegion, IJ; kwargs...)
 
-    "imageset: http://docs.sympy.org/latest/modules/sets.html"
-    global imageset(fn::Function, args...) = begin
-        x = Sym("x")
-        imageset(x, fn(x), args...)
-    end
-    global imageset(args...) = sympy_meth(:imageset, args...)
+"imageset: http://docs.sympy.org/latest/modules/sets.html"
+global imageset(fn::Function, args...) = begin
+    x = Sym("x")
+    imageset(x, fn(x), args...)
+end
+global imageset(args...) = sympy_meth(:imageset, args...)
 
 
-    ## Interval
+## Interval
 
 """
 Create an interval object
@@ -236,7 +234,6 @@ Interval(0,1,true, false) # (0,1]
 ```
 
 """
-    global Interval(l,r,left_open=false, right_open=false) = sympy_meth(:Interval, Sym(l), Sym(r), left_open ,right_open)
+global Interval(l,r,left_open=false, right_open=false) = sympy_meth(:Interval, Sym(l), Sym(r), left_open ,right_open)
 
 
-end


### PR DESCRIPTION
This moves around some code in the init files. Calling this module in with reexport was throwing some warnings and this shifting quiets those. The function `julia_code` was commented out for this reason. Its functionality is now accessed through `sympy_meth(:julia_code, ex)` instead of `julia_code(ex)`, when available.