### PR TITLE
replaced UTF8String for 0.6

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -16,13 +16,24 @@ pprint(s::SymbolicObject, args...; kwargs...) = sympy_meth(:pprint, s, args...; 
 "Call SymPy's `latex` function. Not exported. "
 latex(s::SymbolicObject, args...; kwargs...)  = sympy_meth(:latex, s, args...; kwargs...)
 
-"create basic printed output"
-function jprint(x::SymbolicObject)
-    out = PyCall.pycall(pybuiltin("str"), Compat.UTF8String, PyObject(x))
-    if ismatch(r"\*\*", out)
-        out = replace(out, "**", "^")
+if VERSION < v"0.6.0"
+    "create basic printed output"
+    function jprint(x::SymbolicObject)
+        out = PyCall.pycall(pybuiltin("str"), Compat.UTF8String, PyObject(x))
+        if ismatch(r"\*\*", out)
+            out = replace(out, "**", "^")
+        end
+        out
     end
-    out
+else
+    "create basic printed output"
+    function jprint(x::SymbolicObject)
+        out = PyCall.pycall(pybuiltin("str"), String, PyObject(x))
+        if ismatch(r"\*\*", out)
+            out = replace(out, "**", "^")
+        end
+        out
+    end
 end
 jprint(x::AbstractArray) = map(jprint, x)
 

--- a/test/test-matrix.jl
+++ b/test/test-matrix.jl
@@ -25,8 +25,8 @@ end
     @test @compat simplify.(inv(A) * A) ==  eye(2)
     @test @compat simplify.(A * inv(A)) == eye(2)
     @test @compat simplify.(A[:inv]() - inv(A)) == zeros(2, 2)
-    @test adjoint(B) == [conj(x) 0; 1 conj(2x)]
-    @test adjoint(B) == B'
+    @test SymPy.adjoint(B) == [conj(x) 0; 1 conj(2x)]
+    @test SymPy.adjoint(B) == B'
     @test dual(A) == zeros(2, 2)
 
 


### PR DESCRIPTION
In julia 0.6 you get
```Julia
WARNING: Compat.UTF8String is deprecated, use String instead.
in jprint at ~/.julia/v0.6/SymPy/src/display.jl
```
So to fix this warning, I replaced it with `String` for juila 0.6 and above, while maintaing compatibility for previous versions.