### PR TITLE
extended lambdify function

### DIFF
--- a/src/lambdify.jl
+++ b/src/lambdify.jl
@@ -94,8 +94,8 @@ end
 
 """
 
-`lambidfy(ex::Sym,[vars])`: Lambidfy an expression returning a native
-Julia function.  SymPy's
+`lambidfy(ex::Sym,[vars];type=Any)`: Lambidfy an expression returning a
+native Julia function.  SymPy's
 [lambdify](http://docs.sympy.org/dev/modules/utilities/lambdify.html)
 function translates code into Python, this translates an expression
 into a `Julia` function.
@@ -111,6 +111,8 @@ not covered by the default ones. These are dictionaries whose keys are
 strings with a SymPy name and whose values are symbols representing
 `Julia` values. For examples `Dict("sin"=>:sin)` could be used to map
 a function, were that not already done.
+
+Additionally, a DataType keyword can be specified for the function.
 
 Not all expressions can be lambdified. If not, an error is thrown.
 
@@ -136,7 +138,7 @@ map(lambdify(ex), xs)    # 0.007085 seconds
 This is a *temporary* solution. The proper fix is to do this in SymPy.
 
 """
-function lambdify(ex::Sym, vars=free_symbols(ex); fns=Dict(), values=Dict())
+function lambdify(ex::Sym, vars=free_symbols(ex); typ=Any, ns=Dict(), values=Dict())
     # if :julia_code printer is there, use it
     if haskey(sympy, :julia_code)
         body = parse(sympy_meth(:julia_code, ex))
@@ -145,8 +147,9 @@ function lambdify(ex::Sym, vars=free_symbols(ex); fns=Dict(), values=Dict())
     end
     try
         fn = eval(Expr(:function,
-                  Expr(:call, gensym(), map(Symbol,vars)...),
-                       body))
+            Expr(:call, gensym(),
+                map(s->Expr(:(::),s,typ), Symbol.(vars))...),
+            body))
         (args...) -> invokelatest(fn, args...) # https://github.com/JuliaLang/julia/pull/19784
     catch err
         throw(ArgumentError("Expression does not lambdify"))
@@ -154,6 +157,59 @@ function lambdify(ex::Sym, vars=free_symbols(ex); fns=Dict(), values=Dict())
 end
 
 export(lambdify)
+
+"""
+
+`lambidfy_expr(ex::Sym,[vars];type=Any,name=gensym())`: Lambidfy an expression
+returning a native Julia function `Expr` object.  SymPy's
+[lambdify](http://docs.sympy.org/dev/modules/utilities/lambdify.html)
+function translates code into Python, this translates an expression
+into a `Julia` function `Expr` object.
+
+The function can be evaluated and doesn't call SymPy, so should be much faster.
+
+The optional `[vars]` specifies the order of the variables when more
+than one is in `ex`. The default is to use the ordering of
+`free_symbols(ex)`.
+
+The keyword aruguments allow for the passing of expressions that are
+not covered by the default ones. These are dictionaries whose keys are
+strings with a SymPy name and whose values are symbols representing
+`Julia` values. For examples `Dict("sin"=>:sin)` could be used to map
+a function, were that not already done.
+
+Additionally, a DataType keyword can be specified for the function.
+
+Not all expressions can be lambdified. If not, an error is thrown.
+
+Some simple examples
+
+```
+@vars x y
+lambdify_expr(x^2;typ=Int,name=:square)
+lambdify_expr(x*y^2)            # using default ordering
+lambdify_expr(x*y^2, [y, x])    # alternate ordering
+```
+
+"""
+function lambdify_expr(ex::Sym, vars=free_symbols(ex); name=gensym(), typ=Any, ns=Dict(), values=Dict())
+    # if :julia_code printer is there, use it
+    if haskey(sympy, :julia_code)
+        body = parse(sympy_meth(:julia_code, ex))
+    else
+        body = walk_expression(ex, fns=fns, values=values)
+    end
+    try
+        Expr(:function,
+            Expr(:call, name,
+                 map(s->Expr(:(::),s,typ), Symbol.(vars))...),
+            body)
+    catch err
+        throw(ArgumentError("Expression does not lambdify"))
+    end
+end
+
+export(lambdify_expr)
 
 function init_lambdify()
 #    if haskey(sympy, :julia_code)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -448,7 +448,7 @@ end
         @test u(.5) == 1
         @test u(1.5) == 0
 
-        i2 = SymPy.lambdify_expr(x^2,name=:square,typ=Int)
+        i2 = SymPy.lambdify_expr(x^2,name=:square)
         @test i2.head == :function
         @test i2.args[1].args[1] == :square
         @test i2.args[2] == :(x.^2)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -447,6 +447,11 @@ end
         u = lambdify(i)
         @test u(.5) == 1
         @test u(1.5) == 0
+
+        i2 = SymPy.lambdify_expr(x^2,name=:square,typ=Int)
+        @test i2.head == :function
+        @test i2.args[1].args[1] == :square
+        @test i2.args[2] == :(x.^2)
     end
 
     ## issue #67


### PR DESCRIPTION
extended lambdify function so you can do something like

```Julia
julia> @vars u; lambdify_expr(u^2;typ=Int,name=:square)
:(function square(u::Int64)
        u .^ 2
    end)
```

I also intend to create another pull-request to fix the 0.7.0 issues (if this doesn't get merged yet by then, I might add it to this pull request)