### PR TITLE
Fix CSE for scalar and array cases

### DIFF
--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -2,7 +2,7 @@
 ## from http://docs.sympy.org/0.7.2/modules/simplify/simplify.html
 
 ## simple methods (x, args) -> y (y coercion happens via PyCall)
-simplify_sympy_meths = (:collect, :rcollect, :separate, 
+simplify_sympy_meths = (:collect, :rcollect, :separate,
                         :separatevars,
                         :radsimp, :ratsimp, :trigsimp, :besselsimp,
                         :powsimp, :combsimp, :hypersimp,
@@ -11,7 +11,7 @@ simplify_sympy_meths = (:collect, :rcollect, :separate,
                         :posify, :powdenest, :sqrtdenest,
                         :logcombine, :hyperexpand)
 
-                            
+
 expand_sympy_meths = (:expand_trig,
                       :expand_power_base, :expand_power_exp,
                       :expand_log,
@@ -32,13 +32,9 @@ Example: (from man page)
 cse(((w + x + y + z)*(w + y + z))/(w + x)^3), ([(x0, y + z), (x1, w + x)], [(w + x0)*(x0 + x1)/x1^3]) # tuple of replacements and reduced expressions.
 
 """ ->
-cse{T<:SymbolicObject}(ex::T, args...; kwargs...) = sympy_meth(:cse, ex, args...; kwargs...)
-cse{T<:SymbolicObject}(ex::Vector{T}, args...; kwargs...) = sympy_meth(:cse, ex, args...; kwargs...)
-        
-function cse{T<:SymbolicObject, N}(ex::AbstractArray{T, N}, args...; kwargs...)
-    a,b = cse(ex[:], args...; kwargs...)
-    bb = convert(Array{Sym},  reshape(b, size(ex)))
-    a, bb
+function cse{T<:SymbolicObject}(ex::Union{T, AbstractArray{T}}, args...; kwargs...)
+    a, b = sympy_meth(:cse, ex, args...; kwargs...)
+    a, oftype(ex, b[1])
 end
 export(cse)
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -178,7 +178,7 @@ end
     @vars a b; eqs = (a*x+2y-3, 2b*x + 3y - 4)
     as = linsolve(eqs, x, y)
     @test length(elements(as)) == 1
-    
+
     ## limits
     @test limit(x -> sin(x)/x, 0) == 1
     @test limit(sin(x)/x, x, 0) |> float == 1
@@ -474,6 +474,12 @@ end
     y = Sym(eps())
     @test round(y, 5) == 0
     @test round(y, 16) != 0
+
+    ## test cse output
+    @test cse(x) == (Any[], x)
+    @test cse([x]) == (Any[], [x])
+    @test cse([x, x]) == (Any[], [x, x])
+    @test cse([x x; x x]) == (Any[], [x x; x x])
 
 ## sympy"..."(...)
 @vars x


### PR DESCRIPTION
Right now, at least in my setup, the output part of CSE results is nested inside an unnecessary array.
Additionally, the CSE of matrices simply fails.
This PR tries to fix that.

I'm not convinced that this is not a problem of my setup alone.
That can be confirmed by trying the added tests yourselves.