### PR TITLE
close #223

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -80,7 +80,8 @@ function convert(::Type{Sym}, x::Complex)
     y = ifelse(isa(x, Complex{Bool}), real(x) + imag(x) * im, x)
     real(y) + imag(y) * IM
 end
-convert(::Type{Complex}, x::Sym) = complex(map(x -> convert(Float64, x), x[:as_real_imag]())...)::Sym
+convert(::Type{Complex}, x::Sym) = complex(map(x -> convert(Float64, x), x[:as_real_imag]())...)
+complex(::Type{Sym}) = Sym
 complex(x::Sym) = convert(Complex, x)
 complex(xs::AbstractArray{Sym}) = map(complex, xs)
 


### PR DESCRIPTION
adds `complex(::Type{Sym}) = Sym`

But `complex(x::Sym)` needs work. It should convert real numbers to complex. We can't (?) add to the assumptions on `x` as a Symbolic object, so there is a conversion to a `Julia` value, but perhaps it is best to just define as `complex(r::Sym, i::Sym=zero(Sym)) = N(r) + im * N(i)`.