### PR TITLE
Issue230

### DIFF
--- a/src/subs.jl
+++ b/src/subs.jl
@@ -169,7 +169,8 @@ function N(ex::Sym)
         catch e
         end
     end
-    throw(DomainError())
+    ex  # do nothing if not a number
+#    throw(DomainError())
 end
 N(x::Number) = x  # implies N(x::Sym) = x if ...
 N(m::AbstractArray{Sym}) = map(N, m)

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -134,7 +134,7 @@ rts = solve(x^5 - x + 1)
 The `evalf` function is similar, though it leaves the expression as a symbolic object.
 This breaks the similarity of N and evalf for sympy users.
 
-Throws a `DomainError` if no conversion is possible, such as when the expression still has symbolic values.
+Returns the value unchanged when it has free symbols.
 
 `N` is type unstable.
 
@@ -142,6 +142,9 @@ Throws a `DomainError` if no conversion is possible, such as when the expression
 function N(ex::Sym)
     ## more work than I'd like
     ## XXX consolidate this and N(ex, digits)
+
+    length(free_symbols(ex)) > 0 && return ex
+    
     if is_integer(ex) == nothing
         evalf_ex = ex[:evalf]()
         if ex == evalf_ex
@@ -169,8 +172,7 @@ function N(ex::Sym)
         catch e
         end
     end
-    ex  # do nothing if not a number
-#    throw(DomainError())
+    throw(DomainError())
 end
 N(x::Number) = x  # implies N(x::Sym) = x if ...
 N(m::AbstractArray{Sym}) = map(N, m)


### PR DESCRIPTION
This modifies the behaviour on `N` for symbols. Rather than throw a domain error, it returns the symbol. This proves useful with conversions (e.g., see `real` or `imag`.)

This came up in the discussion surrounding #230.

This is a breaking change.