### PR TITLE
Updated deprecation warning in eval()

### DIFF
--- a/src/dsolve.jl
+++ b/src/dsolve.jl
@@ -80,7 +80,7 @@ macro symfuns(x...)
         end
     end
     push!(q.args, Expr(:tuple, fs...)) # return all of the functions we created
-    eval(Main, q)
+    Core.eval(Main, q)
 end
 
 


### PR DESCRIPTION
Updated a warning in Julia 0.7 that would let to problems in Julia 1.0:
`eval(Main,q) ==> Core.eval(Main,q)`
(this rise up in `@symfuns f`)