### PR TITLE
address issues 244,245

### DIFF
--- a/src/dsolve.jl
+++ b/src/dsolve.jl
@@ -181,6 +181,7 @@ end
 ## out is an equation in var with constants. Args are intial conditions
 ## Return `nothing` if initial condition is not satisfied (found by `solve`)
 function _solve_ivp(out, var, args, o)
+
     eqns = Sym[rhs(diff(out, var, f.n))(var=>x0) - y0 for (f, x0, y0) in args]
     sols = solve(eqns, Sym["C$i" for i in 1:o])
     if length(sols) == 0

--- a/src/logical.jl
+++ b/src/logical.jl
@@ -8,14 +8,14 @@ logical_sympy_methods = (:Eq, :Ne, :Lt, :Le, :Gt, :Ge)
 ## not exported
 const relational_sympy_values = (:GreaterThan, :LessThan,
                                  :StrictGreaterThan, :StrictLessThan,
-                                 :Equality, :Unequality)  
-for meth in relational_sympy_values           
+                                 :Equality, :Unequality)
+for meth in relational_sympy_values
     meth_name = string(meth)
     @eval begin
 #         @doc """
 # `$($meth_name)`: a SymPy function. [cf.](http://docs.sympy.org/dev/_modules/sympy/core/relational.html)
 # """ ->
-        ($meth)(a::Real, b::Real) = sympy_meth($meth_name,a, b)
+        ($meth)(a::Real, b::Real) = _sympy_meth($meth_name,a, b)
     end
 #    eval(Expr(:export, meth))
 end
@@ -25,9 +25,9 @@ end
 
 ## XXX Experimental! Not sure these are such a good idea ...
 ## but used with piecewise
-Base.:&(x::Sym, y::Sym) = PyCall.pycall(PyObject(x)["__and__"], Sym, y) 
-Base.:|(x::Sym, y::Sym) =  PyCall.pycall(PyObject(x)["__or__"], Sym, y) 
-!(x::Sym)         =       PyCall.pycall(x.x["__invert__"], Sym)::Sym 
+Base.:&(x::Sym, y::Sym) = PyCall.pycall(PyObject(x)["__and__"], Sym, y)
+Base.:|(x::Sym, y::Sym) =  PyCall.pycall(PyObject(x)["__or__"], Sym, y)
+!(x::Sym)         =       PyCall.pycall(x.x["__invert__"], Sym)::Sym
 
 ## use ∨, ∧, ¬ for |,&,! (\vee<tab>, \wedge<tab>, \neg<tab>)
 ∨(x::Sym, y::Sym) = x | y
@@ -47,7 +47,7 @@ Base.:|(x::Sym, y::Sym) =  PyCall.pycall(PyObject(x)["__or__"], Sym, y)
 ## * `>`  is `\gg<tab>`
 
 
-## Instead we have: 
+## Instead we have:
 ## We use unicode for visual appeal of infix operators, but the Lt, Le, Eq, Ge, Gt are the proper way:
 
 "This is `\\ll<tab>` mapped as an infix operator to `Lt`"
@@ -64,14 +64,14 @@ Base.:|(x::Sym, y::Sym) =  PyCall.pycall(PyObject(x)["__or__"], Sym, y)
 (≦)(a::Number, b::Sym) = Le(Sym(a),b)   # \ll<tab>
 
 "This is `\\gg<tab>` mapped as an infix operator to `Gt`"
-(≫)(a::Sym, b::Sym) = Gt(a,b) |> asBool 
-(≫)(a::Sym, b::Number) = Gt(a,Sym(b)) 
-(≫)(a::Number, b::Sym) = Gt(Sym(a),b) 
+(≫)(a::Sym, b::Sym) = Gt(a,b) |> asBool
+(≫)(a::Sym, b::Number) = Gt(a,Sym(b))
+(≫)(a::Number, b::Sym) = Gt(Sym(a),b)
 
 "This is `\\geqq<tab>` mapped as an infix operator to `Ge`"
-(≧)(a::Sym, b::Sym) = Ge(a,b) |> asBool 
-(≧)(a::Sym, b::Number) = Ge(a,Sym(b))  
-(≧)(a::Number, b::Sym) = Ge(Sym(a),b) 
+(≧)(a::Sym, b::Sym) = Ge(a,b) |> asBool
+(≧)(a::Sym, b::Number) = Ge(a,Sym(b))
+(≧)(a::Number, b::Sym) = Ge(Sym(a),b)
 
 "For infix `Eq` one can use \\Equal<tab> unicode operator"
 (⩵)(a::Sym, b::Sym) = Eq(a,b)  # \Equal<tab>
@@ -111,7 +111,7 @@ Base.isequal(a::Sym, b::Number) = asBool(Eq(promote(a,b)...))
 Base.isequal(a::Number, b::Sym) = asBool(Eq(promote(a,b)...))
 
 function !=(x::Sym, y::T)  where {T <: Real}
-    try 
+    try
         x = convert(Float64, x)
         x != y
     catch
@@ -119,7 +119,7 @@ function !=(x::Sym, y::T)  where {T <: Real}
     end
 end
 function !=(x::Sym, y::T) where {T <: Complex}
-    try 
+    try
         x = complex(x)
         x != y
     catch
@@ -128,5 +128,5 @@ function !=(x::Sym, y::T) where {T <: Complex}
 end
 
 function init_logical()
-    global SympyTRUE = sympy_meth(:Lt, 0,1)
+    global SympyTRUE = _sympy_meth(:Lt, 0,1)
 end

--- a/src/ntheory.jl
+++ b/src/ntheory.jl
@@ -30,11 +30,11 @@ function primerange(a::Sym,b)
     primes(a,b)
 end
 export primerange
-    
+
 ## Combinatorics
 import Base: binomial
-binomial(n::Sym,k) = sympy_meth(:binomial, n, k)
-binomial(n, k::Union{SA, Integer}) where {SA <: Sym} = sympy_meth(:binomial, n, k)
+binomial(n::Sym,k) = _sympy_meth(:binomial, n, k)
+binomial(n, k::Union{SA, Integer}) where {SA <: Sym} = _sympy_meth(:binomial, n, k)
 
 combinatoric_sympy_methods = (:bell,
                               :bernoulli,
@@ -47,4 +47,3 @@ combinatoric_sympy_methods = (:bell,
                               :nC,
                               :nK
                               )
-                              

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -8,7 +8,7 @@
 const SymPoly = Sym
 
 
-Base.divrem(p::Sym, q::Sym) = sympy_meth(:div, p, q)
+Base.divrem(p::Sym, q::Sym) = _sympy_meth(:div, p, q)
 Base.div(p::Sym, q::Sym) = divrem(p,q)[1]
 Base.rem(p::Sym, q::Sym) = divrem(p,q)[2]
 
@@ -42,7 +42,7 @@ polyrem(ex::Sym, args...; kwargs...) = rem(ex, args...; kwargs...)
 Polynomial division with remainder. Renamed from `divrem` in SymPy to avoid confusion with Julia's `divrem`
 
 """
-polydivrem(ex::Sym, args...; kwargs...) = sympy_meth(:div, ex, args...; kwargs...)
+polydivrem(ex::Sym, args...; kwargs...) = _sympy_meth(:div, ex, args...; kwargs...)
 
 
 """
@@ -101,11 +101,11 @@ polynomial_sympy_methods = (
 #                            :roots ## conflict with Roots.roots and functionality provided by solve
                             )
 
-degree(x::Sym;kwargs...) = sympy_meth(:degree, x; kwargs...)
+degree(x::Sym;kwargs...) = _sympy_meth(:degree, x; kwargs...)
 export degree
 
-denom(x::Sym) = sympy_meth(:denom, x)
-numer(x::Sym) = sympy_meth(:numer, x)
+denom(x::Sym) = _sympy_meth(:denom, x)
+numer(x::Sym) = _sympy_meth(:numer, x)
 export denom, numer
 Base.denominator(x::SymbolicObject) = denom(x)
 Base.numerator(x::SymbolicObject) = numer(x)
@@ -170,7 +170,7 @@ polynomial_instance_methods = (:EC, :ET, :LC, :LM, :LT, :TC, ## no .abs()
 """
 
     coeffs(p, [x])
-    
+
 Return coefficients, `[a0, a1, ..., an]`, of a polynomial `p = a0 + a1*x + ... + an*x^n` in `D[x]`.
 
 Note: SymPy has the `all_coeffs` function to do this for objects of class `Poly`. The SymPy `coeffs` function returns the non-zero values. Use `sympy"coeffs"` for this functionality.
@@ -255,6 +255,6 @@ interpolate(1:4, sin.(1:4), x)     # xs, ys
 interpolate([(1,2), (2,3), (3,2)], x)  # [(x1,y1), ..., (xn, yn)]
 ```
 """
-interpolate(xsys::AbstractVector, x) = sympy_meth(:interpolate, xsys, x)
+interpolate(xsys::AbstractVector, x) = _sympy_meth(:interpolate, xsys, x)
 interpolate(xs::AbstractVector, ys::AbstractVector, x::Sym) = interpolate(collect(zip(xs, ys)), x)
 export interpolate

--- a/src/specialfuns.jl
+++ b/src/specialfuns.jl
@@ -12,7 +12,7 @@ hankelh1, hankelh1x, hankelh2, hankelh2x, zeta
 
 
 
-                        
+
 ## https://github.com/JuliaMath/SpecialFunctions.jl/blob/master/src/SpecialFunctions.jl
 ## julia -> sympy mapping.
 julia_sympy_map = (
@@ -111,7 +111,7 @@ julia_sympy_map = (
 
 )
 
-                      
+
 for (jmeth, smeth) in [(j,s) for (j,s) in julia_sympy_map if s !== :nothing && j!== :nothing]
     meth_name = string(smeth)
     eval(Expr(:import, :SpecialFunctions, jmeth))
@@ -120,7 +120,7 @@ for (jmeth, smeth) in [(j,s) for (j,s) in julia_sympy_map if s !== :nothing && j
         # `$($meth_name)`: a SymPy function.
         #     The SymPy documentation can be found through: http://docs.sympy.org/latest/search.html?q=$($meth_name)
         #     """ ->
-        ($jmeth)(x::Sym, xs...;kwargs...) = sympy_meth($meth_name, x, xs...; kwargs...)
+        ($jmeth)(x::Sym, xs...;kwargs...) = SymPy._sympy_meth($meth_name, x, xs...; kwargs...)
     end
     eval(Expr(:export,smeth))
 end
@@ -134,7 +134,7 @@ for meth in [v for (k,v) in julia_sympy_map if k == :nothing]
         #     `$($meth_name)`: a SymPy function.
         #         The SymPy documentation can be found through: http://docs.sympy.org/latest/search.html?q=$($meth_name)
         #         """ ->
-        ($meth)(xs...; kwargs...) = sympy_meth($meth_name, xs...; kwargs...)
+        ($meth)(xs...; kwargs...) = SymPy._sympy_meth($meth_name, xs...; kwargs...)
     end
     eval(Expr(:export, meth))
 end
@@ -152,7 +152,7 @@ lgamma(x::Sym) = log(gamma(x))
 for fn in (:besselj, :bessely, :besseli, :besselk)
     meth = string(fn)
     eval(Expr(:import, :SpecialFunctions, fn))
-    @eval ($fn)(nu::Number, x::Sym; kwargs...) = sympy_meth($meth, nu, x; kwargs...)
+    @eval ($fn)(nu::Number, x::Sym; kwargs...) = SymPy._sympy_meth($meth, nu, x; kwargs...)
     @eval ($fn)(nu::Number, a::AbstractArray{Sym}) = map(x ->$fn(nu, x), a)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -47,7 +47,7 @@ symbols(x::Symbol; kwargs...) = symbols(string(x); kwargs...)
 ## Thanks to vtjnash for this!
 """
     @syms x [y z ...] [assumptions...]
-    
+
 Macro to create many symbolic objects at once.
 
 The `@syms` macros creates the variables and assigns them into the
@@ -73,7 +73,7 @@ Additionally you can rename arguments using pairs notation:
 
 The `@vars` macro is similar, `@syms` is the name used in
 MATLAB.
-    
+
 Original macro magic contributed by @vtjnash and extended by @alhirzel and
 @spencerlyon2
 """
@@ -105,7 +105,7 @@ end
 # TODO alias @vars to @syms
 """
     @vars x y z
-  
+
 The `vars` macro is identical to  `@syms`.
 
 """
@@ -202,7 +202,7 @@ function getindex(x::SymbolicObject, i::Symbol)
     else
        MethodError()
     end
-end 
+end
 
 ## Override this so that using symbols as keys in a dict works
 Base.hash(x::Sym) = hash(PyObject(x))
@@ -216,5 +216,3 @@ end
 
 " Return class name as a string "
 classname(ex::Sym) = PyObject(ex)[:__class__][:__name__]
-
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,5 +7,5 @@ include("test-matrix.jl")
 include("test-ode.jl")
 include("test-logical.jl")
 include("test-specialfuncs.jl")  ## XXX NEEDS WORK
-include("test-permutations.jl") 
+include("test-permutations.jl")
 include("test-physics.jl")

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -526,6 +526,10 @@ end
     fn = lambdify(expr, use_julia_code=true)
     @test fn(1.0im) == 0.0 - 1.0im
 
+    # issue 245 missing sincos
+    @test applicable(sincos, x)
+    @test sincos(x)[1] == sin(x)
+
 end
 
 @testset "generic programming, issue 223" begin


### PR DESCRIPTION
* add `sincos`
* to address #244, for most functions rather than falling back to letting `PyAny` determine the type through automatic conversion, we use `Sym` on a `PyObject`. This seems to have speed benefits when able to be used.