### PR TITLE
Use default script in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,5 @@ notifications:
 before_install:
     #install mpmath to test functionallity
   - if [ $MPMATH = "true" ]; then julia -e 'using Pkg; Pkg.add("Conda"); using Conda; Conda.add("mpmath")';fi
-script:
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'using Pkg; Pkg.clone(pwd()); Pkg.build("SymPy"); Pkg.test("SymPy"; coverage=true)'
 after_success: 
   - julia -e 'using Pkg; Pkg.add("Coverage"); cd(Pkg.dir("SymPy")); using Coverage; Coveralls.submit(process_folder())'


### PR DESCRIPTION
Travis now has robust default script for Julia so that you can just omit `script:` in `.travis.yml` and it just works:
https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/script/julia.rb

This is something I had to during the reverse dependency testing #251.  It's not fixing anything, but I thought you may want to do it as you've already dropped Julia 0.6 support.
