### PR TITLE
Getitem close #273

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.jl.cov
+*.jl.*.cov
+*.jl.mem
+docs/build
+docs/site
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -3,13 +3,11 @@ uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-OffsetArrays = "≥ 0.10.0"
 PyCall = "≥ 1.90.0"
 RecipesBase = "≥ 0.5.0"
 SpecialFunctions = "≥ 0.3.4"

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,3 @@ julia 1.0.0
 PyCall 1.90.0
 RecipesBase 0.5.0
 SpecialFunctions 0.3.4
-OffsetArrays 0.10.0

--- a/src/SymPy.jl
+++ b/src/SymPy.jl
@@ -34,7 +34,6 @@ using PyCall
 
 using SpecialFunctions
 using LinearAlgebra
-using OffsetArrays
 
 
 import Base: show

--- a/src/matrix.jl
+++ b/src/matrix.jl
@@ -101,9 +101,6 @@ Base.inv(x::SymMatrix) = x.inv()
 -(x::SymMatrix, y::SymMatrix) = x + y.multiply(-1)
 ^(x::SymMatrix, y::Union{Int, SymbolicObject}) = pycall(sympy.Pow, SymMatrix, x, y)
 
-#### Add 0-based getindex, setindex! methods
-using OffsetArrays
-
 """
    M[i,j]
 
@@ -112,26 +109,9 @@ Define `getindex` for SymPy's `ImmutableMatrix` class.
 SymMatrix is 0-based, like python, not Julia. Use Matrix{Sym} for that.
 
 """
-function Base.getindex(M::SymMatrix, i::Int, j::Int)
-    N = M.tolist()[i+1, j+1]
-    N
-end
-function Base.getindex(M::SymMatrix, I...)
-    m, n = M.shape
-    U = OffsetArray(convert(Matrix{Sym}, M), 0:m-1, 0:n-1)
-    V = getindex(U, I...)
-    # V is funny a bit, slices across rows return vectors too!
-    if isa(V, AbstractArray)
-        convert(SymMatrix, collect(V))
-    else
-        V
-    end
-end
-
-# method for vectors, linear indexing
-Base.getindex(V::SymMatrix, i::Int) = V[i,0]
+Base.getindex(M::SymMatrix, i::Int, j::Int) = M.__getitem__((i,j))
+Base.getindex(V::SymMatrix, i::Int) = V.__getitem__((i,0))
 Base.getindex(M::SymMatrix) = M
-Base.lastindex(M::SymMatrix, i::Int) = M.shape[i]
 
 function Base.convert(::Type{SymMatrix}, M::AbstractArray{T, N}) where {T <: Number, N}
     m,n = size(M)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,26 @@
 ## Getindex default.
 ## Is this the proper default?
+"""
+
+   x[i]
+
+Some SymPy Python objects have index notation provided for them through `__getitem__`. This allows Julia's `getindex` to dispatch to Python's `__getitem__`. The index (indices) must be symbolic. This will use 0-based indexing, as it is a simple pass through to Python.
+
+Examples:
+```
+i,j = sympy.symbols("i j", integer=True)
+x = sympy.IndexedBase("x")
+a = sympy.Sum(x[i], (i, 1, j))
+```
+
+"""
 function Base.getindex(x::Sym, xs::Sym...)
     if pycall_hasproperty(x, :__getitem__)
-        return x.__getitem__(xs...)
+        return x.__getitem__(xs)
     elseif pycall_hasproperty(x, :__getslice__)
-        return x.__getslice__(xs...)
+        return x.__getslice__(xs)
     else
+
         # no indexing defined, but this won't effect broadcasting
         x
     end
@@ -101,7 +116,7 @@ subs(d::Pair...; kwargs...)           = ex -> subs(ex, [(p.first, p.second) for 
 # avoid type piracy. After we call `pytype` mappings, some
 # objects are automatically converted and no longer PyObjects
 pycall_hasproperty(x::PyCall.PyObject, k) = PyCall.hasproperty(x, k)
-pycall_hasproperty(x::Sym, k) = PyCall.hasproperty(PyCall.PyObject(x), k)
+pycall_hasproperty(x::SymbolicObject, k) = PyCall.hasproperty(PyCall.PyObject(x), k)
 pycall_hasproperty(x, k) = false
 
 # simple helper for boolean properties

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -165,7 +165,7 @@ end
 
 # default list of modules to search for namespace collicsions
 const base_Ms = (Base, SpecialFunctions, Base.MathConstants,
-           LinearAlgebra, OffsetArrays
+           LinearAlgebra
            )
 
 # default list of methods to exclude from importing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,16 @@
+## Getindex default.
+## Is this the proper default?
+function Base.getindex(x::Sym, xs::Sym...)
+    if pycall_hasproperty(x, :__getitem__)
+        return x.__getitem__(xs...)
+    elseif pycall_hasproperty(x, :__getslice__)
+        return x.__getslice__(xs...)
+    else
+        # no indexing defined, but this won't effect broadcasting
+        x
+    end
+end
+
 
 ## Call
 ## Call symbolic object with natural syntax

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -550,6 +550,10 @@ end
     J = [diff(x, u) for x in xs, u in (rho, phi, theta)]
     J.det()
 
+    # issue #273 x[i]
+    x = sympy.IndexedBase("x")
+    i,j = sympy.symbols("i j", integer=True)
+    @test x[i] == PyCall.py"$x[$i]"
 
 end
 


### PR DESCRIPTION
In #273 it becomes clear that `x[i]` is not defined for objects that it could be defined for. This adds a default `getindex` method for Sym objects with Sym indices. The default when no underlying SymPy method is available is chosen to work with broadcasting.