### PR TITLE
order return value of free_symbols

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.0.4"
+version = "1.0.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -260,12 +260,23 @@ end
 
 
 
-##
+"""
+   free_symbols(ex)
+
+Return free symbols of expression or vector of expressions. The results are orderded by
+`sortperm(string.(fs))`.
+
+```
+@vars x y z a
+free_symbols(2*x + a*y) # [a, x, y]
+```
+"""
 function free_symbols(ex::Union{T, Vector{T}}) where {T<:SymbolicObject}
     pex = PyObject(ex)
     #fs.__class__.__name__ == "set"
     if PyCall.hasproperty(pex, :free_symbols)
-        convert(Vector{Sym}, collect(pex.free_symbols))
+        fs = convert(Vector{Sym}, collect(pex.free_symbols))
+        fs[sortperm(string.(fs))]   # some sorting order to rely on
     else
         Sym[]
     end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -26,8 +26,10 @@ import PyCall
 
 
     ## extract symbols
-    ex = x*y
+    @vars z
+    ex = x*y*z
     @test isa(free_symbols(ex), Vector{Sym})
+    @test free_symbols(ex) == [x, y, z]
 
     ## number conversions
     @test Sym(2) == 2


### PR DESCRIPTION
It seems desirable for `free_symbols` to return it values in a predictable manner. This returns `fs[sortperm(string.(fs))]` where `fs` are the free symbols.