### PR TITLE
add promote_op methods; close issue #324

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.0.13"
+version = "1.0.14"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -6,7 +6,6 @@
 
 +(x::SymbolicObject, y::SymbolicObject) = x.__add__(y)
 *(x::SymbolicObject, y::SymbolicObject) = x.__mul__(y)
-
 -(x::SymbolicObject, y::SymbolicObject) = x.__sub__(y)
 -(x::SymbolicObject)                    = x.__neg__()
 /(x::SymbolicObject, y::SymbolicObject) = x.__div__(y)

--- a/src/numbers.jl
+++ b/src/numbers.jl
@@ -3,6 +3,10 @@
 ## promote up to symbolic so that math ops work
 promote_rule(::Type{T}, ::Type{S})  where {T<:SymbolicObject, S<:Number}= T
 Base.promote_type(::Type{Irrational{T}}, ::Type{Sym}) where {T} = Sym
+Base.promote_op(::T, ::Type{S}, ::Type{Sym}) where {T, S <: Number} = Sym
+Base.promote_op(::T, ::Type{Sym}, ::Type{S}) where {T, S <: Number} = Sym
+Base.promote_op(::T, ::Type{Sym}, ::Type{Sym}) where {T} = Sym # This helps out linear algebra conversions
+
 ## Conversion
 convert(::Type{T}, o::PyCall.PyObject) where {T <: SymbolicObject} = T(o)
 convert(::Type{PyObject}, s::Sym) = s.__pyobject__

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -584,6 +584,13 @@ end
     @test integrate(x -> 1, 0, 1)  == 1
     @test limit(x->1,  x, 0) == 1
     @test diff(x->1)  ==   0
+
+    ## Issue 324 with inference of matrix operations
+    A = fill(Sym("a"), 2, 2)
+    @test eltype(A*A) == Sym
+    @test eltype(A*ones(2,2)) == Sym
+    @test eltype(A*Diagonal([1,1])) == Sym
+    @test_broken eltype(A * I(2)) == Sym
 end
 
 @testset "generic programming, issue 223" begin


### PR DESCRIPTION
This only mostly closes 324; as no solution to `A * I` or `A*I(n)` is provided when A is a matrix with symbolic values.