### PR TITLE
Issue 332

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.0.15"
+version = "1.0.16"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -11,7 +11,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 PyCall = "1.91"
 RecipesBase = "0.7"
-SpecialFunctions = "0.8, 0.9"
+SpecialFunctions = "0.8, 0.9, 0.10"
 julia = "1.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.0.16"
+version = "1.0.17"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -2,7 +2,7 @@
 
 
 Base.abs(x::SymbolicObject) = sympy.Abs(x)
-Base.abs2(x::SymbolicObject) = abs(x)^2
+Base.abs2(x::SymbolicObject) = x * conj(x)
 Base.max(x::Sym, a) = sympy.Max(x, a)
 Base.min(x::Sym, a) = sympy.Min(x, a)
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -597,6 +597,13 @@ end
     ex = 3 * sympy.E * x
     fn = lambdify(ex)
     @test fn(1) ≈ 3*exp(1) * 1
+
+    ## Issue 332 with `abs2`
+    @vars x real=true
+    @test abs2(x) == x*x
+    @vars x
+    @test abs2(x) == x*conj(x)
+
 end
 
 @testset "generic programming, issue 223" begin


### PR DESCRIPTION
This defines `abs2(x)=  x*conj(x)`.  It could be, following   Julia's  defn for ::Complex, `real(x)*real(x) +  imag(x)*imag(x)`. These aren't the same without some extra  work to simplify, and this defn. prints more compactly. It  should definitely not be  what it is. If  this proves  troublesome  we can change.