### PR TITLE
Lambdify speedup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.0.31"
+version = "1.0.32"
 
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-Linux: [![Build Status](https://travis-ci.org/JuliaPy/SymPy.jl.svg?branch=master)](https://travis-ci.org/JuliaPy/SymPy.jl)
+[![Build Status](https://travis-ci.com/jverzani/SymPy.jl.svg?branch=master)](https://travis-ci.com/jverzani/SymPy.jl)
 &nbsp;
-Windows: [![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaPy/SymPy.jl?branch=master&svg=true)](https://ci.appveyor.com/project/jverzani/sympy-jl)
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliahub.com/docs/SymPy)
 
 


### PR DESCRIPTION
* reorganizes `lambdify` code
* gives two examples of how to make faster functions from expressions than the default for `lambdify`
* version bump
* change travis link in README