### PR TITLE
Fix and document @vars renaming with pair syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build status](https://github.com/JuliaPy/SymPy.jl/workflows/CI/badge.svg)](https://github.com/JuliaPy/SymPy.jl/actions)
+[![Build status](https://github.com/JuliaPy/SymPy.jl/workflows/CI/badge.svg)](https://github.com/JuliaPy/SymPy.jl/actions)
 &nbsp;
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliahub.com/docs/SymPy)
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -107,6 +107,14 @@ julia> solve(u1 + u2)  # empty, though solving u1 - u2 is not.
 
 ```
 
+Additionally you can rename arguments using pair notation:
+```
+julia> @vars a1=>"α₁" a2=>"α₂"
+(α₁, α₂)
+```
+
+In this example, the Julia variables `a1` and `a2` are defined to store SymPy
+symbols with the "pretty" names `α₁` and `α₂` respectively.
 
 As can be seen, there are several ways to create symbolic values. One
 caveat is that one can't use `Sym` to create a variable from a

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -8,11 +8,12 @@ symbols(xs::T...; kwargs...) where {T <: SymbolicObject} = xs
 """
     @vars x y z
 
-Define symbolic values, possibly with assumptions
+Define symbolic values, possibly with names and assumptions
 
 Examples:
 ```
 @vars x y
+@vars a1=>"α₁"
 @vars a b real=true
 ```
 
@@ -26,15 +27,15 @@ macro vars(x...)
             if s.head == :(=)
                 s.head = :kw
                 push!(as, s)
-            elseif s.head == :(=>)
-                push!(ss, s.args[1])
-                push!(q.args, Expr(:(=), esc(s.args[1]), Expr(:call, :symbols, s.args[2], map(esc,as)...)))
+            elseif s.head == :call && s.args[1] == :(=>)
+                push!(ss, s.args[2])
+                push!(q.args, Expr(:(=), esc(s.args[2]), Expr(:call, :symbols, s.args[3], map(esc,as)...)))
             end
         elseif isa(s, Symbol)   # raw symbol to be created
             push!(ss, s)
             push!(q.args, Expr(:(=), esc(s), Expr(:call, :symbols, Expr(:quote, s), map(esc,as)...)))
         else
-            throw(AssertionError("@syms expected a list of symbols and assumptions"))
+            throw(AssertionError("@vars expected a list of symbols and assumptions"))
         end
     end
     push!(q.args, Expr(:tuple, map(esc,reverse(ss))...)) # return all of the symbols we created

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -24,6 +24,9 @@ import PyCall
     @test_throws UndefVarError isdefined(w)
     @vars a b c
 
+    # Renaming with @vars
+    @vars a=>"α₁"
+    @test a.name == "α₁"
 
     ## extract symbols
     @vars z


### PR DESCRIPTION
This fixes the support for `variable=>name` syntax in `@vars`, and adds a few mentions of this syntax in the documentation.

There's also a minor fix in the Readme for the CI badge.