### PR TITLE
wrap latex in markdown to work with Pluto; close #400

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.0.36"
+version = "1.0.37"
 
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"

--- a/src/SymPy.jl
+++ b/src/SymPy.jl
@@ -36,7 +36,7 @@ using PyCall
 
 using SpecialFunctions
 using LinearAlgebra
-
+using Markdown
 
 import Base: show
 import Base: convert, promote_rule

--- a/src/symfunction.jl
+++ b/src/symfunction.jl
@@ -77,9 +77,9 @@ derivative(x::SymFunction, d::Int = 1) = SymFunction(x.__pyobject__, x.n + d)
 
 Base.show(io::IO, u::SymFunction) = print(io, "$(string(Sym(u.__pyobject__)))" * repeat("'", u.n))
 Base.show(io::IO, ::MIME"text/plain", u::SymFunction) = print(io, "$(string(Sym(u.__pyobject__)))" * repeat("'", u.n))
-Base.show(io::IO, ::MIME"text/latex", x::SymFunction) = print(io, "\\begin{align*}" * latex(x) * "\\end{align*}")
+Base.show(io::IO, ::MIME"text/latex", x::SymFunction) = print(io, as_markdown("\\begin{align*}" * latex(x) * "\\end{align*}"))
 function Base.show(io::IO, ::MIME"text/latex", x::AbstractArray{SymFunction, 1})
-    print(io, "\\begin{align*}\\left[\\begin{array}{c}" * join(latex.(x), "\\\\") * "\\end{array}\\right]\\end{align*}")
+    print(io, as_markdown("\\begin{align*}\\left[\\begin{array}{c}" * join(latex.(x), "\\\\") * "\\end{array}\\right]\\end{align*}"))
 end
 
 latex(x::SymFunction) = latex(Sym(x.__pyobject__)) * repeat("'", x.n)


### PR DESCRIPTION
close #400 

To get printing in pluto this wraps latex expressions in `Markdown.parse("``...``")`. Seems like there should be a more performant way than parsing, but performance seemed not be an issue in limited testing.