### PR TITLE
Add new @syms syntax

### DIFF
--- a/test/tests.jl
+++ b/test/tests.jl
@@ -489,7 +489,6 @@ end
 
 @testset "Syms macro" begin
     x, y, z, n = @syms x::(real,positive)=>"x₀", y, z::complex, n::integer
-
     @test isa(x, Sym)
     @test ask(And(𝑄.real(x), 𝑄.positive(x)))
     @test string(x) == "x₀"
@@ -501,6 +500,16 @@ end
     
     @test isa(n, Sym)
     @test ask(𝑄.integer(n))
+
+    f, g, h = @syms f()::(real, positive), g(), h()::complex=>"h̄"
+    @test isa(f, SymFunction)
+    @test ask(And(𝑄.real(f(x)), 𝑄.positive(f(x))))
+
+    @test isa(g, SymFunction)
+
+    @test isa(h, SymFunction)
+    @test ask(𝑄.complex(h(x)))
+    @test string(h) == "h̄"
 end
 
 @testset "SymFunctions" begin

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -487,8 +487,24 @@ import PyCall
     #@test sympy"sin"(1) == sin(Sym(1))
 end
 
+@testset "Syms macro" begin
+    x, y, z, n = @syms x::(real,positive)=>"x₀", y, z::complex, n::integer
+
+    @test isa(x, Sym)
+    @test ask(And(𝑄.real(x), 𝑄.positive(x)))
+    @test string(x) == "x₀"
+    
+    @test isa(y, Sym)
+
+    @test isa(z, Sym)
+    @test ask(𝑄.complex(z))
+    
+    @test isa(n, Sym)
+    @test ask(𝑄.integer(n))
+end
+
 @testset "SymFunctions" begin
-    @syms x y real=true
+    @syms x::real y::real
     @symfuns f g real=true
 
     @test isreal(f(x))


### PR DESCRIPTION
See #416 

I just noticed the `@symfuns` macro which has the syntax of `@vars`, this is may be confusing as well. Would you like me to do something about it?