### PR TITLE
add tilde, following Symbolics; fix issue from #425

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -106,7 +106,6 @@ julia> sqrt(u(x)^2), sqrt(v(x)^2) # sqrt(u(x)^2), Abs(v(x))
 !!! Note:
     Many thanks to `@matthieubulte` for this contribution.
 """
-
 macro syms(xs...)
     # If the user separates declaration with commas, the top-level expression is a tuple
     if length(xs) == 1 && isa(xs[1], Expr) && xs[1].head == :tuple

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -84,6 +84,20 @@ end
 
 
 ## Add interfaces for solve, nonlinsolve when vector of equations passed in
+
+## An alternative to Eq(lhs, rhs) following Symbolics.jl
+"""
+    lhs ~ rhs
+
+Specify an equation.
+
+Alternative syntax to `Eq(lhs, rhs)` or `lhs ⩵ rhs` (`\\Equal[tab]`) following `Symbolics.jl`.
+"""
+Base.:~(lhs::Number, rhs::SymbolicObject) = Eq(lhs, rhs)
+Base.:~(lhs::SymbolicObject, rhs::Number) = Eq(lhs, rhs)
+Base.:~(lhs::SymbolicObject, rhs::SymbolicObject) = Eq(lhs, rhs)
+
+
 """
     solve
 

--- a/src/numbers.jl
+++ b/src/numbers.jl
@@ -351,9 +351,9 @@ export ∨, ∧, ¬
 ## (≪)(a::Number, b::Number) = Lt(promote(a,b)...)  # \ll<tab>
 
 "This is `\\leqq<tab>` mapped as an infix operator to `Le`"
-(≦)(a::Sym, b::Sym) = Le(a,b)   # \ll<tab>
-(≦)(a::Sym, b::Number) = Le(a,Sym(b))  # \ll<tab>
-(≦)(a::Number, b::Sym) = Le(Sym(a),b)   # \ll<tab>
+(≦)(a::Sym, b::Sym) = Le(a,b)   # \leqq<tab>
+(≦)(a::Sym, b::Number) = Le(a,Sym(b))  # \leqq<tab>
+(≦)(a::Number, b::Sym) = Le(Sym(a),b)   # \leqq<tab>
 
 "This is `\\gg<tab>` mapped as an infix operator to `Gt`"
 (≫)(a::Sym, b::Sym) = Gt(a,b) |> asBool

--- a/src/numbers.jl
+++ b/src/numbers.jl
@@ -356,12 +356,12 @@ export ∨, ∧, ¬
 (≦)(a::Number, b::Sym) = Le(Sym(a),b)   # \leqq<tab>
 
 "This is `\\gg<tab>` mapped as an infix operator to `Gt`"
-(≫)(a::Sym, b::Sym) = Gt(a,b) |> asBool
+(≫)(a::Sym, b::Sym) = Gt(a,b) 
 (≫)(a::Sym, b::Number) = Gt(a,Sym(b))
 (≫)(a::Number, b::Sym) = Gt(Sym(a),b)
 
 "This is `\\geqq<tab>` mapped as an infix operator to `Ge`"
-(≧)(a::Sym, b::Sym) = Ge(a,b) |> asBool
+(≧)(a::Sym, b::Sym) = Ge(a,b) 
 (≧)(a::Sym, b::Number) = Ge(a,Sym(b))
 (≧)(a::Number, b::Sym) = Ge(Sym(a),b)
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -440,7 +440,7 @@ import PyCall
     @test args(ex) == (x^2, x)
 
     # alternative operators
-    for ex1,ex2 ∈ ((Eq(x^2, x), x^2 ⩵ x),
+    for (ex1,ex2) ∈ ((Eq(x^2, x), x^2 ⩵ x),
                    (Eq(x^2, x), x^2 ~ x),
                    (Lt(x^2, x), x^2 ≪ x),
                    (Le(x^2, x), x^2 ≦ x),

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -434,10 +434,21 @@ import PyCall
 
     ## relations
     x,y=symbols("x, y")
-    ex = Eq(x^2, x)
+    ex  = Eq(x^2, x)
     @test ex.lhs() == x^2
     @test ex.rhs() == x
     @test args(ex) == (x^2, x)
+
+    # alternative operators
+    for ex1,ex2 ∈ ((Eq(x^2, x), x^2 ⩵ x),
+                   (Eq(x^2, x), x^2 ~ x),
+                   (Lt(x^2, x), x^2 ≪ x),
+                   (Le(x^2, x), x^2 ≦ x),
+                   (Ge(x^2, x), x^2 ≧ x),
+                   (Gt(x^2, x), x^2 ≫ x))
+        @test lhs(ex1) == lhs(ex2)
+        @test rhs(ex1) == rhs(ex2)
+    end
 
     ## mpmath functions
 #    if @isdefined mpmath


### PR DESCRIPTION
* add `~` as an alternative to `lhs \Equal[tabl] rhs` or `Eq(lhs, rhs)` so that comparisons with `Symbolics` are easier.
* fix space issue exposed in response to issue #425