### PR TITLE
support specialfunctions 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ CommonSolve = "0.2"
 Latexify = "0.15"
 PyCall = "1.91"
 RecipesBase = "0.7, 0.8, 1.0, 1.1"
-SpecialFunctions = "0.8, 0.9, 0.10, 1.0"
+SpecialFunctions = "0.8, 0.9, 0.10, 1.0, 2"
 julia = "1.0"
 
 [extras]


### PR DESCRIPTION
The only breaking change in SpecialFunctions 2.0 [was deleting](https://github.com/JuliaMath/SpecialFunctions.jl/pull/297) the `factorial(x::Real) = gamma(x+1)` function, and since you don't use `factorial` for non-integer/symbolic arguments this shouldn't affect you.