### PR TITLE
add interface for nsolve

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.1.5"
+version = "1.1.6"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -146,6 +146,13 @@ linsolve(V::AbstractArray{T,N}, args...; kwargs...) where {T <: SymbolicObject, 
 linsolve(Ts::Tuple, args...; kwargs...) where {T <: SymbolicObject} =
     sympy.linsolve(Ts, args...; kwargs...)
 
+nsolve(V::AbstractArray{T,N}, args...; kwargs...) where {T <: SymbolicObject, N} =
+    sympy.nsolve(V, args...; kwargs...)
+nsolve(Ts::Tuple, args...; kwargs...) where {T <: SymbolicObject} =
+    sympy.nsolve(Ts, args...; kwargs...)
+
+
+
 
 ## dsolve allowing initial condiation to be specified
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -209,9 +209,13 @@ import PyCall
     @test length(elements(as)) == 1
 
     ## nsolve -- not method for arrays, issue 268
+    ## Add interface for nsolve
     @vars z1 z2z1 positive=true
-    @test_throws MethodError nsolve([z1^2-1, z1+z2z1-2], [z1,z2z1], [1,1])  # non symbolic first argument
-    @test all(N.(sympy.nsolve([z1^2-1, z1+z2z1-2], [z1,z2z1], (1,1))) .≈ [1.0, 1.0])
+    #@test_throws MethodError nsolve([z1^2-1, z1+z2z1-2], [z1,z2z1], [1,1])  # non symbolic first argument
+    @test all(N.(nsolve([z1^2-1, z1+z2z1-2], [z1,z2z1], (1,1))) .≈ [1.0, 1.0])
+
+
+
 
     ## issue 355: direct definition of LinearAlgebra.:\
     @test_throws SingularException Sym[1 1; 1 1] \ [1, 2]


### PR DESCRIPTION
This came up in #268 and again in https://discourse.julialang.org/t/help-with-solving-symbolic-nonlinear-system-of-equations/80077 Adding the interface for arrays and tuples seems for `nsolve` seems apt.