### PR TITLE
rework round and trunc

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.1.6"
+version = "1.1.7"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"

--- a/test/test-ode.jl
+++ b/test/test-ode.jl
@@ -1,7 +1,7 @@
 using SymPy
 using Test
 
-@testset "ODes" begin
+@testset "ODEs" begin
     ## ODEs
     x, a = Sym("x, a")
     F = SymFunction("F")

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -772,6 +772,21 @@ end
     @syms x
     ex = integrate(sqrt(1 + (1/x)^2), (x, 1/sympy.E, sympy.E))
     @test N(ex) ≈ 3.196198513599507
+
+    ## Issue #472
+    @syms x
+    a = Sym(1)/2
+    @test round(x) == x
+    @test round(a) == 0
+    @test round(a, RoundUp) == 1
+    @test round(PI; digits = 2) * 100 == 314  # this one is odd
+    @test trunc(x) == x
+    @test trunc(PI) == 3
+    @test trunc(-PI) == -3
+    @test typeof(trunc(PI)) == typeof(PI)
+    M = [PI -PI; a x]
+    @test round.(M) == [3 -3; 0 x]
+
 end
 
 @testset "generic programming, issue 223" begin


### PR DESCRIPTION
This introduces these semantics for round and trunc

* both pass on non real values
* trunc and round return Sym objects (this is a change)
* round only uses the `digits` argument.