### PR TITLE
fix `SymPySymbolicUtilsExt` extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.1.11"
+version = "1.1.12"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"
@@ -16,7 +16,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [extensions]
-SymPyTermSymbolicUtilsExt = "SymbolicUtils"
+SymPySymbolicUtilsExt = "SymbolicUtils"
 
 [compat]
 CommonEq = "0.2"

--- a/Project.toml
+++ b/Project.toml
@@ -33,4 +33,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 
 [targets]
-test = ["Test"]
+test = ["SymbolicUtils", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,11 +2,9 @@ if lowercase(get(ENV, "CI", "false")) == "true"
     include("install_dependencies.jl")
 end
 
-
-
-
 using SymPy
 using Test
+import SymbolicUtils  # test loading extension
 
 include("tests.jl")
 include("test-math.jl")


### PR DESCRIPTION
Fix https://github.com/JuliaPy/SymPy.jl/issues/515.

Extensions (weak dependencies) **should be tested in CI** by adding a `using <weak dependencies>` to `runtests.jl` in order to trigger extension loading.

cc @jverzani, please merge & tag asap ? Thanks.