### PR TITLE
add 2-arg hash leveraging PyCall and PythonCall approaches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymPy"
 uuid = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
-version = "1.1.12"
+version = "1.1.13"
 
 [deps]
 CommonEq = "3709ef60-1bee-4518-9f2f-acd86f176c50"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,4 +4,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.24, 1"

--- a/docs/src/Tutorial/matrices.md
+++ b/docs/src/Tutorial/matrices.md
@@ -974,9 +974,9 @@ julia> M = Sym[3 -2  4 -2; 5  3 -3 -2; 5 -2  2 -2; 5 -2 -3  3]
 
 julia> M.eigenvals()
 Dict{Any, Any} with 3 entries:
-  -2 => 1
   3  => 1
   5  => 2
+  -2 => 1
 
 ```
 

--- a/docs/src/Tutorial/solvers.md
+++ b/docs/src/Tutorial/solvers.md
@@ -519,8 +519,8 @@ julia> solveset(x^3 - 6*x^2 + 9*x, x)
 ```jldoctest solvers
 julia> roots(x^3 - 6*x^2 + 9*x, x)  |>  d -> convert(Dict{Sym, Any}, d) # prettier priting
 Dict{Sym, Any} with 2 entries:
-  3 => 2
   0 => 1
+  3 => 2
 ```
 
 ----

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1210,8 +1210,8 @@ julia> v = solveset(x^2 ~ 4, x)
 
 julia> collect(Set(v...))
 2-element Vector{Any}:
- -2
   2
+ -2
 
 ```
 
@@ -1220,8 +1220,8 @@ This composition is done in the `elements` function:
 ```jldoctest introduction
 julia> elements(v)
 2-element Vector{Sym}:
- -2
   2
+ -2
 
 ```
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -16,7 +16,3 @@ end
 Modules = [SymPy, SymPy.Q, SymPy.Introspection]
 Order   = [:function, :constant, :macro, :type, :module]
 ```
-
-```@docs
-𝑄
-```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -18,5 +18,5 @@ Order   = [:function, :constant, :macro, :type, :module]
 ```
 
 ```@docs
-SymPy.𝑄
+𝑄
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -16,3 +16,7 @@ end
 Modules = [SymPy, SymPy.Q, SymPy.Introspection]
 Order   = [:function, :constant, :macro, :type, :module]
 ```
+
+```@docs
+SymPy.𝑄
+```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -13,5 +13,6 @@ end
 ```
 
 ```@autodocs
-Modules = [SymPy]
+Modules = [SymPy, SymPy.Q, SymPy.Introspection]
+Order   = [:function, :constant, :macro, :type, :module]
 ```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -13,6 +13,6 @@ end
 ```
 
 ```@autodocs
-Modules = [SymPy, SymPy.Q, SymPy.Introspection]
+Modules = [SymPy, SymPy.𝑄, SymPy.Introspection]
 Order   = [:function, :constant, :macro, :type, :module]
 ```

--- a/src/assumptions.jl
+++ b/src/assumptions.jl
@@ -350,8 +350,6 @@ end
 ## export
 #export Q
 
-#const 𝑄 = Q
-
 """
     𝑄
 

--- a/src/assumptions.jl
+++ b/src/assumptions.jl
@@ -354,14 +354,14 @@ export 𝑄
 ## export
 #export Q
 
-"""
-    Q
+# """
+#     Q
 
-Unexported  symbol for  [`SymPy.𝑄`](@ref), a  Julia  module implementing `sympy.Q`. "Questions" can be asked through the patterns
-`𝑄.query(value)`
+# Unexported  symbol for  [`SymPy.𝑄`](@ref), a  Julia  module implementing `sympy.Q`. "Questions" can be asked through the patterns
+# `𝑄.query(value)`
 
-!!! note
-    At one time, the symbol `Q` was exported. To avoid namespace clutter, the unicode alternative is now used. Legacy code would need a definition like `import SymPy: Q` to work.
+# !!! note
+#     At one time, the symbol `Q` was exported. To avoid namespace clutter, the unicode alternative is now used. Legacy code would need a definition like `import SymPy: Q` to work.
 
-"""
+# """
 const Q = 𝑄

--- a/src/assumptions.jl
+++ b/src/assumptions.jl
@@ -53,7 +53,7 @@ export ask
     𝑄
     SymPy.Q
 
-Documentation for the `SymPy.Q` module, exported as `𝑄`.
+The`SymPy.𝑄` module adds features of the `sympy.Q` module. Also accesible through `SymPy.Q`.
 
 SymPy allows for
 [assumptions](https://docs.sympy.org/latest/modules/assumptions/index.html)
@@ -71,7 +71,7 @@ julia> @vars y real=true positive=true
 (y,)
 ```
 
-The `Q` module exposes a means to *q*uery the assumptions on a
+The `𝑄` module exposes a means to *q*uery the assumptions on a
 variable. For example,
 
 ```jldoctest 𝑄
@@ -109,7 +109,7 @@ The above use `&` as an infix operation for the binary operator
 type and not as matrices within Python, the predicate functions from SymPy for
 matrices are not used, though a replacement is given.
 """
-module Q
+module 𝑄
 import SymPy
 import PyCall
 import LinearAlgebra: det, norm
@@ -345,20 +345,20 @@ end
 
 
 end
+export 𝑄
 
 ## Issue  #354; request to *not*  export  Q
 ## export
 #export Q
 
 """
-    𝑄
+    Q
 
-Exported  symbol for  [`SymPy.Q`](@ref), a  Julia  module implementing `sympy.Q`. "Questions" can be asked through the patterns
+Unexported  symbol for  [`SymPy.𝑄`](@ref), a  Julia  module implementing `sympy.Q`. "Questions" can be asked through the patterns
 `𝑄.query(value)` (𝑄 is entered as  [slash]itQ[tab]) or `SymPy.Q.query(value)` *but  not* as `sympy.Q.query(value)`
 
 !!! note
-    At one time, the symbol `Q` was exported for this. To avoid namespace clutter, the unicode alternative is now used. Legacy code would need a definition like `const Q = SymPy.Q`  to work.
+    At one time, the symbol `Q` was exported. To avoid namespace clutter, the unicode alternative is now used. Legacy code would need a definition like `import SymPy: Q` to work.
 
 """
-const 𝑄 = Q
-export 𝑄
+const Q = 𝑄

--- a/src/assumptions.jl
+++ b/src/assumptions.jl
@@ -350,7 +350,7 @@ end
 ## export
 #export Q
 
-const 𝑄 = Q
+#const 𝑄 = Q
 
 """
     𝑄
@@ -362,6 +362,5 @@ Exported  symbol for  [`SymPy.Q`](@ref), a  Julia  module implementing `sympy.Q`
     At one time, the symbol `Q` was exported for this. To avoid namespace clutter, the unicode alternative is now used. Legacy code would need a definition like `const Q = SymPy.Q`  to work.
 
 """
-𝑄
-export  𝑄
-
+const 𝑄 = Q
+export 𝑄

--- a/src/assumptions.jl
+++ b/src/assumptions.jl
@@ -104,6 +104,9 @@ The above use `&` as an infix operation for the binary operator
 `And`. Values can also be combined with `Or`, `Not`, `Xor`, `Nand`,
 `Nor`, `Implies`, `Equivalent`, and `satisfiable`.
 
+!!! note "typing `𝑄`"
+    𝑄 is entered as  [slash]itQ[tab]) or `SymPy.Q.query(value)` *but  not* as `sympy.Q.query(value)`
+
 !!! note "Matrix predicates"
     As `SymPy.jl` converts symbolic matrices into Julia's `Array`
 type and not as matrices within Python, the predicate functions from SymPy for
@@ -253,7 +256,7 @@ function positive_definite(M::Array{T,2}) where {T <: SymPy.Sym}
     no_false = 0
     no_nothing = 0
     for i in 1:m
-        a = SymPy.ask(Q.positive(det(M[1:i, 1:i])))
+        a = SymPy.ask(𝑄.positive(det(M[1:i, 1:i])))
         if a == nothing no_nothing += 1 end
         if a == false no_false += 1 end
     end
@@ -355,7 +358,7 @@ export 𝑄
     Q
 
 Unexported  symbol for  [`SymPy.𝑄`](@ref), a  Julia  module implementing `sympy.Q`. "Questions" can be asked through the patterns
-`𝑄.query(value)` (𝑄 is entered as  [slash]itQ[tab]) or `SymPy.Q.query(value)` *but  not* as `sympy.Q.query(value)`
+`𝑄.query(value)`
 
 !!! note
     At one time, the symbol `Q` was exported. To avoid namespace clutter, the unicode alternative is now used. Legacy code would need a definition like `import SymPy: Q` to work.

--- a/src/types.jl
+++ b/src/types.jl
@@ -61,7 +61,12 @@ export Lambda
 ## this allows most things to flow though PyCall
 PyCall.PyObject(x::SymbolicObject) = x.__pyobject__
 ## Override this so that using symbols as keys in a dict works
-hash(x::SymbolicObject) = hash(PyObject(x))
+function Base.hash(x::SymbolicObject, h::UInt)
+    o = PyObject(x)
+    px = ccall((PyCall.@pysym :PyObject_Hash), PyCall.Py_hash_t, (PyCall.PyPtr,), o) # from PyCall.jl
+    reinterpret(UInt, Int(px)) - 3h                                                  # from PythonCall.jl
+end
+#hash(x::SymbolicObject) = hash(PyObject(x))
 ==(x::SymbolicObject, y::SymbolicObject) = PyObject(x) == PyObject(y)
 
 ##################################################


### PR DESCRIPTION
This closes #520 leveraging code from both PyCall and PythonCall.

It also addresses https://discourse.julialang.org/t/sympy-sym-s-as-keys-in-dicts/103995

