### PR TITLE
Bump SymbolicUtils.jl compat to v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ CommonSolve = "0.2"
 LinearAlgebra = "<0.0.1, 1.6"
 PyCall = "1.96.2"
 SpecialFunctions = "0.7, 0.8, 0.8, 0.10, 1, 2"
-SymbolicUtils = "1"
+SymbolicUtils = "1, 2"
 SymPyCore = "0.2, 1"
 julia = "1.6"
 


### PR DESCRIPTION
This is required for both tests to work on the latest version and to unblock downstream.